### PR TITLE
fix: skip repeat_set when entity already playing, add announce=true

### DIFF
--- a/src/ha_client.py
+++ b/src/ha_client.py
@@ -85,26 +85,36 @@ class HAClient:
         return bool(supported & SUPPORT_REPEAT_SET)
 
     def _play_media(self, entity_id: str, audio_url: str) -> bool:
-        """Call media_player.play_media with common params."""
+        """Call media_player.play_media with announce=enqueue.
+
+        announce=True tells the player this is an intercom announcement —
+        Music Assistant handles resume/stop naturally.
+        """
         return self.call(
             "media_player/play_media",
             {
                 "entity_id": entity_id,
                 "media_content_id": audio_url,
                 "media_content_type": "music",
+                "announce": True,
             },
         )
 
     def play_and_auto_pause(self, entity_id: str, audio_url: str, duration: float) -> bool:
         """Play audio — auto-stop via repeat_set or pause depending on speaker support.
 
-        If speaker supports repeat_set: set repeat=off → play (speaker stops
-        naturally, no timing issue). Otherwise fall back to play → sleep(duration)
-        → pause + retry.
+        Strategy:
+        - Save pre-play state. If entity was already playing music, leave repeat
+          alone so the player resumes after the announcement.
+        - If NOT playing and speaker supports repeat_set: set repeat=off → play
+          with announce=True (speaker stops naturally after announcement).
+        - Otherwise fall back to play → sleep(duration) → pause + retry.
 
         Returns True if play_media succeeded.
         """
-        if self.supports_repeat_set(entity_id):
+        was_playing = self.state(entity_id) == "playing"
+
+        if not was_playing and self.supports_repeat_set(entity_id):
             self.call(
                 "media_player/repeat_set",
                 {
@@ -119,13 +129,22 @@ class HAClient:
                 print(f"[intercom] HA play failed for {entity_id}")
             return ok
 
-        # Fallback: play + background auto-pause timer
+        # Already was playing (or no repeat_set support):
+        # let announce=True in _play_media handle resume naturally.
+        if was_playing:
+            print(f"[intercom] {entity_id} was already playing — announce mode (will resume)")
+
         ok = self._play_media(entity_id, audio_url)
         if not ok:
             print(f"[intercom] HA play failed for {entity_id}")
             return False
 
-        # Spawn background thread for auto-pause
+        # If was playing, trust announce=True to handle resume — no pause needed.
+        if was_playing:
+            print(f"[intercom] {entity_id} announced (resume handled by player)")
+            return True
+
+        # Fallback: play + background auto-pause timer
         threading.Thread(
             target=self._auto_pause_bg,
             args=(entity_id, duration),

--- a/tests/test_ha_client.py
+++ b/tests/test_ha_client.py
@@ -331,7 +331,7 @@ class TestAutoPauseBg:
         mock_start.assert_not_called()
 
     def test_repeat_set_path_skips_auto_pause(self):
-        """When repeat_set is supported, no background thread is spawned."""
+        """When idle + repeat_set supported: set repeat=off, play, no thread."""
         client = HAClient("http://ha:8123", "tok")
         mock_resp = MagicMock()
         mock_resp.status = 200
@@ -348,6 +348,64 @@ class TestAutoPauseBg:
 
         assert result is True
         mock_start.assert_not_called()
+
+    def test_was_playing_skips_repeat_set(self):
+        """When already playing + repeat_set: no repeat_set call, announce mode."""
+        client = HAClient("http://ha:8123", "tok")
+        mock_state_resp = MagicMock()
+        mock_state_resp.status = 200
+        mock_state_resp.read.return_value = json.dumps(
+            {"state": "playing", "attributes": {"supported_features": SUPPORT_REPEAT_SET}}
+        ).encode()
+
+        call_args = []
+        def fake_call(service, data):
+            call_args.append((service, data))
+            return True
+
+        with (
+            patch.object(client, "call", side_effect=fake_call),
+            patch.object(client, "supports_repeat_set", return_value=True),
+            patch("urllib.request.urlopen", return_value=mock_state_resp),
+            patch("threading.Thread.start") as mock_start,
+        ):
+            result = client.play_and_auto_pause(
+                "media_player.test", "http://ha/audio/test.wav", 2.0
+            )
+
+        assert result is True
+        # Should NOT call repeat_set when was_playing=True
+        repeat_calls = [s for s, _ in call_args if "repeat_set" in s]
+        assert len(repeat_calls) == 0
+        # Should call play_media with announce=True
+        play_calls = [d for s, d in call_args if s == "media_player/play_media"]
+        assert len(play_calls) == 1
+        assert play_calls[0].get("announce") is True
+        # No background thread needed (announce handles resume)
+        mock_start.assert_not_called()
+
+    def test_play_media_includes_announce(self):
+        """play_media always includes announce=True for intercom behavior."""
+        client = HAClient("http://ha:8123", "tok")
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.read.return_value = b"{}"
+
+        call_data = {}
+        def fake_call(service, data):
+            if service == "media_player/play_media":
+                call_data.update(data)
+            return True
+
+        with (
+            patch.object(client, "call", side_effect=fake_call),
+            patch("threading.Thread.start"),
+        ):
+            client.play_and_auto_pause(
+                "media_player.test", "http://ha/audio/test.wav", 2.0
+            )
+
+        assert call_data.get("announce") is True
 
 
 class TestSupportsRepeatSet:


### PR DESCRIPTION
Built on top of #2.

## Problem

Reported by @ngocjohn in #1: after cutoff fix, new bug — HomePod starts playing music from MA queue after broadcast.

## Root cause

`repeat_set(off)` was unconditional. On Music Assistant, setting repeat=off triggers queue playback.

## Fix (3 changes)

1. **Save pre-play state** — `was_playing = state(entity_id) == "playing"` before broadcast
2. **Conditional repeat_set** — only call `repeat_set(off)` when NOT already playing
3. **`announce: true`** in play_media — standard HA intercom announcement parameter

## Behavior matrix

| Pre-play | repeat_set support | Action |
|---|---|---|
| Not playing | Yes | repeat=off → play (self-stopping) |
| Not playing | No | play → sleep+pause timer |
| Playing | Yes/No | play with announce=true (resume by player) |