### PR TITLE
feat: PWA light/dark theme switcher with auto mode

### DIFF
--- a/custom_components/home_intercom/intercom.html
+++ b/custom_components/home_intercom/intercom.html
@@ -24,13 +24,21 @@
 })();
 </script>
 <script>
-// Set initial title from saved language before i18n.js loads
+// Set initial title + theme before CSS/i18n to avoid a flash of the wrong look
 (function(){
   var lang = localStorage.getItem("intercom-lang") || "";
   // Read HA user language from localStorage (same origin)
   var haLang = localStorage.getItem("selectedLanguage") || "";
   var isEn = lang === "en" || (!lang && (haLang.includes("en") || haLang.includes("en-")));
   document.title = isEn ? "Home Intercom" : "家庭广播";
+
+  var pref = localStorage.getItem("intercom-theme") || "auto";
+  if (pref !== "light" && pref !== "dark") pref = "auto";
+  var dark = !window.matchMedia || window.matchMedia("(prefers-color-scheme: dark)").matches;
+  var theme = pref === "light" ? "light" : pref === "dark" ? "dark" : (dark ? "dark" : "light");
+  document.documentElement.setAttribute("data-theme", theme);
+  var meta = document.querySelector('meta[name="theme-color"]');
+  if (meta) meta.setAttribute("content", theme === "light" ? "#f3f3f4" : "#0f0f0f");
 })();
 </script>
 <script src="/static/i18n.js"></script>
@@ -64,6 +72,16 @@
       <button type="button" id="settings-toggle" class="settings-toggle" aria-haspopup="dialog" aria-expanded="false" aria-controls="settings-overlay">
         <span aria-hidden="true">⚙</span>
       </button>
+      <div class="theme-dropdown" id="theme-dropdown">
+      <button type="button" id="theme-toggle" class="theme-toggle" aria-haspopup="listbox" aria-expanded="false" aria-label="Theme">
+        <span id="theme-toggle-icon" aria-hidden="true"><svg viewBox="0 0 16 16" aria-hidden="true"><circle cx="8" cy="8" r="6" fill="none" stroke="currentColor" stroke-width="1.5"/><path fill="currentColor" d="M8 2a6 6 0 0 0 0 12z"/></svg></span>
+      </button>
+      <div class="lang-dropdown-menu" role="listbox" hidden>
+        <button type="button" role="option" class="lang-option" data-theme-pref="auto" data-i18n="themeAuto">自动</button>
+        <button type="button" role="option" class="lang-option" data-theme-pref="light" data-i18n="themeLight">浅色</button>
+        <button type="button" role="option" class="lang-option" data-theme-pref="dark" data-i18n="themeDark">深色</button>
+      </div>
+      </div>
       <div class="lang-dropdown" id="lang-dropdown">
       <button type="button" id="lang-toggle" aria-haspopup="listbox" aria-expanded="false" aria-label="Language">
         <span id="lang-toggle-label">中文</span>
@@ -653,7 +671,7 @@ function drawChimeWaveform(peaks) {
 
   const barW = w / peaks.length;
   const gap = 1;
-  ctx.fillStyle = '#555';
+  ctx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue('--text-muted').trim() || '#555';
   for (let i = 0; i < peaks.length; i++) {
     const barH = Math.max(2, peaks[i] * h * 0.9);
     const x = i * barW + gap / 2;
@@ -865,6 +883,7 @@ function openSettingsPanel() {
   const toggle = document.getElementById('settings-toggle');
   if (!overlay || !toggle) return;
   if (typeof I18N.closeLangDropdown === 'function') I18N.closeLangDropdown();
+  if (typeof THEME !== 'undefined' && typeof THEME.closeDropdown === 'function') THEME.closeDropdown();
   overlay.hidden = false;
   toggle.setAttribute('aria-expanded', 'true');
   setChimeMsg('');

--- a/custom_components/home_intercom/intercom.html
+++ b/custom_components/home_intercom/intercom.html
@@ -85,7 +85,6 @@
       <div class="lang-dropdown" id="lang-dropdown">
       <button type="button" id="lang-toggle" aria-haspopup="listbox" aria-expanded="false" aria-label="Language">
         <span id="lang-toggle-label">中文</span>
-        <span class="lang-chevron" aria-hidden="true"></span>
       </button>
       <div class="lang-dropdown-menu" role="listbox" hidden>
         <button type="button" role="option" class="lang-option" data-lang="zh-CN">中文</button>

--- a/custom_components/home_intercom/intercom.html
+++ b/custom_components/home_intercom/intercom.html
@@ -37,6 +37,7 @@
   var dark = !window.matchMedia || window.matchMedia("(prefers-color-scheme: dark)").matches;
   var theme = pref === "light" ? "light" : pref === "dark" ? "dark" : (dark ? "dark" : "light");
   document.documentElement.setAttribute("data-theme", theme);
+  document.documentElement.setAttribute("data-theme-pref", pref);
   var meta = document.querySelector('meta[name="theme-color"]');
   if (meta) meta.setAttribute("content", theme === "light" ? "#f3f3f4" : "#0f0f0f");
 })();
@@ -74,7 +75,7 @@
       </button>
       <div class="theme-dropdown" id="theme-dropdown">
       <button type="button" id="theme-toggle" class="theme-toggle" aria-haspopup="listbox" aria-expanded="false" aria-label="Theme">
-        <span id="theme-toggle-icon" aria-hidden="true"><svg viewBox="0 0 16 16" aria-hidden="true"><circle cx="8" cy="8" r="6" fill="none" stroke="currentColor" stroke-width="1.5"/><path fill="currentColor" d="M8 2a6 6 0 0 0 0 12z"/></svg></span>
+        <span id="theme-toggle-icon" aria-hidden="true"></span>
       </button>
       <div class="lang-dropdown-menu" role="listbox" hidden>
         <button type="button" role="option" class="lang-option" data-theme-pref="auto" data-i18n="themeAuto">自动</button>

--- a/custom_components/home_intercom/static/i18n.js
+++ b/custom_components/home_intercom/static/i18n.js
@@ -243,11 +243,6 @@ I18N.init();
 const THEME = (() => {
   const STORAGE_KEY = "intercom-theme";
   const OPTIONS = ["auto", "light", "dark"];
-  const ICONS = {
-    auto: '<svg viewBox="0 0 16 16" aria-hidden="true"><circle cx="8" cy="8" r="6" fill="none" stroke="currentColor" stroke-width="1.5"/><path fill="currentColor" d="M8 2a6 6 0 0 0 0 12z"/></svg>',
-    light: '<svg viewBox="0 0 16 16" aria-hidden="true"><circle cx="8" cy="8" r="2.6" fill="currentColor"/><path fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" d="M8 1.5v1.8M8 12.7v1.8M1.5 8h1.8M12.7 8h1.8M3.3 3.3l1.3 1.3M11.4 11.4l1.3 1.3M3.3 12.7l1.3-1.3M11.4 4.6l1.3-1.3"/></svg>',
-    dark: '<svg viewBox="0 0 16 16" aria-hidden="true"><path fill="currentColor" d="M10.6 2.2a6.2 6.2 0 1 0 3.2 9.2 5.1 5.1 0 0 1-3.2-9.2z"/></svg>',
-  };
   const COLORS = { dark: "#0f0f0f", light: "#f3f3f4" };
   const LABEL_KEYS = { auto: "themeAuto", light: "themeLight", dark: "themeDark" };
 
@@ -264,6 +259,7 @@ const THEME = (() => {
   function apply() {
     const theme = resolved();
     document.documentElement.setAttribute("data-theme", theme);
+    document.documentElement.setAttribute("data-theme-pref", pref);
     const meta = document.querySelector('meta[name="theme-color"]');
     if (meta) meta.setAttribute("content", COLORS[theme]);
     updateDropdown();
@@ -288,9 +284,6 @@ const THEME = (() => {
   }
 
   function updateDropdown() {
-    const icon = document.getElementById("theme-toggle-icon");
-    if (icon) icon.innerHTML = ICONS[pref] || ICONS.auto;
-
     const trigger = document.getElementById("theme-toggle");
     if (trigger && typeof I18N !== "undefined") {
       trigger.setAttribute("aria-label", I18N.t("themeTitle") + " — " + I18N.t(LABEL_KEYS[pref]));

--- a/custom_components/home_intercom/static/i18n.js
+++ b/custom_components/home_intercom/static/i18n.js
@@ -45,6 +45,10 @@ const I18N = (() => {
       chimeUploadTooLong: "音频过长（最多 10 秒）",
       chimePreviewFail: "无法播放",
       chimeResetOk: "已恢复默认提示音",
+      themeTitle: "主题",
+      themeAuto: "自动",
+      themeLight: "浅色",
+      themeDark: "深色",
     },
     en: {
       appTitle: "Home Intercom",
@@ -80,6 +84,10 @@ const I18N = (() => {
       chimeUploadTooLong: "Audio too long (max 10 s)",
       chimePreviewFail: "Cannot play",
       chimeResetOk: "Default chime restored",
+      themeTitle: "Theme",
+      themeAuto: "Auto",
+      themeLight: "Light",
+      themeDark: "Dark",
     },
   };
 
@@ -131,6 +139,7 @@ const I18N = (() => {
 
     trigger.addEventListener("click", (e) => {
       e.stopPropagation();
+      if (typeof THEME !== "undefined" && typeof THEME.closeDropdown === "function") THEME.closeDropdown();
       const open = !root.classList.contains("open");
       root.classList.toggle("open", open);
       trigger.setAttribute("aria-expanded", open ? "true" : "false");
@@ -211,6 +220,7 @@ const I18N = (() => {
     const settingsClose = document.getElementById("settings-close");
     if (settingsToggle) settingsToggle.setAttribute("aria-label", t("settingsTitle"));
     if (settingsClose) settingsClose.setAttribute("aria-label", t("settingsClose"));
+    if (typeof THEME !== "undefined" && typeof THEME.updateDropdown === "function") THEME.updateDropdown();
   }
 
   function init() {
@@ -229,3 +239,122 @@ const I18N = (() => {
 })();
 
 I18N.init();
+
+const THEME = (() => {
+  const STORAGE_KEY = "intercom-theme";
+  const OPTIONS = ["auto", "light", "dark"];
+  const ICONS = {
+    auto: '<svg viewBox="0 0 16 16" aria-hidden="true"><circle cx="8" cy="8" r="6" fill="none" stroke="currentColor" stroke-width="1.5"/><path fill="currentColor" d="M8 2a6 6 0 0 0 0 12z"/></svg>',
+    light: '<svg viewBox="0 0 16 16" aria-hidden="true"><circle cx="8" cy="8" r="2.6" fill="currentColor"/><path fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" d="M8 1.5v1.8M8 12.7v1.8M1.5 8h1.8M12.7 8h1.8M3.3 3.3l1.3 1.3M11.4 11.4l1.3 1.3M3.3 12.7l1.3-1.3M11.4 4.6l1.3-1.3"/></svg>',
+    dark: '<svg viewBox="0 0 16 16" aria-hidden="true"><path fill="currentColor" d="M10.6 2.2a6.2 6.2 0 1 0 3.2 9.2 5.1 5.1 0 0 1-3.2-9.2z"/></svg>',
+  };
+  const COLORS = { dark: "#0f0f0f", light: "#f3f3f4" };
+  const LABEL_KEYS = { auto: "themeAuto", light: "themeLight", dark: "themeDark" };
+
+  let pref = localStorage.getItem(STORAGE_KEY) || "auto";
+  if (!OPTIONS.includes(pref)) pref = "auto";
+
+  const media = window.matchMedia("(prefers-color-scheme: dark)");
+
+  function resolved() {
+    if (pref === "light" || pref === "dark") return pref;
+    return media.matches ? "dark" : "light";
+  }
+
+  function apply() {
+    const theme = resolved();
+    document.documentElement.setAttribute("data-theme", theme);
+    const meta = document.querySelector('meta[name="theme-color"]');
+    if (meta) meta.setAttribute("content", COLORS[theme]);
+    updateDropdown();
+    if (typeof window.updateChimeStatusUI === "function") window.updateChimeStatusUI();
+  }
+
+  function setPref(next) {
+    if (!OPTIONS.includes(next)) return;
+    pref = next;
+    localStorage.setItem(STORAGE_KEY, pref);
+    apply();
+  }
+
+  function closeDropdown() {
+    const root = document.getElementById("theme-dropdown");
+    if (!root) return;
+    root.classList.remove("open");
+    const trigger = document.getElementById("theme-toggle");
+    const menu = root.querySelector(".lang-dropdown-menu");
+    if (trigger) trigger.setAttribute("aria-expanded", "false");
+    if (menu) menu.hidden = true;
+  }
+
+  function updateDropdown() {
+    const icon = document.getElementById("theme-toggle-icon");
+    if (icon) icon.innerHTML = ICONS[pref] || ICONS.auto;
+
+    const trigger = document.getElementById("theme-toggle");
+    if (trigger && typeof I18N !== "undefined") {
+      trigger.setAttribute("aria-label", I18N.t("themeTitle") + " — " + I18N.t(LABEL_KEYS[pref]));
+    }
+
+    document.querySelectorAll("#theme-dropdown [data-theme-pref]").forEach((btn) => {
+      const active = btn.dataset.themePref === pref;
+      btn.classList.toggle("active", active);
+      btn.setAttribute("aria-selected", active ? "true" : "false");
+    });
+  }
+
+  function initDropdown() {
+    const root = document.getElementById("theme-dropdown");
+    if (!root || root.dataset.bound) return;
+    root.dataset.bound = "1";
+
+    const trigger = document.getElementById("theme-toggle");
+    const menu = root.querySelector(".lang-dropdown-menu");
+    if (!trigger || !menu) return;
+
+    trigger.addEventListener("click", (e) => {
+      e.stopPropagation();
+      if (typeof I18N.closeLangDropdown === "function") I18N.closeLangDropdown();
+      const open = !root.classList.contains("open");
+      root.classList.toggle("open", open);
+      trigger.setAttribute("aria-expanded", open ? "true" : "false");
+      menu.hidden = !open;
+    });
+
+    menu.querySelectorAll("[data-theme-pref]").forEach((btn) => {
+      btn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        setPref(btn.dataset.themePref);
+        closeDropdown();
+      });
+    });
+
+    document.addEventListener("click", closeDropdown);
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") closeDropdown();
+    });
+  }
+
+  function onMediaChange() {
+    if (pref === "auto") apply();
+  }
+
+  function init() {
+    const run = () => {
+      initDropdown();
+      apply();
+    };
+    if (media.addEventListener) media.addEventListener("change", onMediaChange);
+    else if (media.addListener) media.addListener(onMediaChange);
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", run);
+    } else {
+      run();
+    }
+  }
+
+  return { init, setPref, apply, closeDropdown, updateDropdown, get pref() { return pref; } };
+})();
+
+THEME.init();
+

--- a/custom_components/home_intercom/static/intercom.css
+++ b/custom_components/home_intercom/static/intercom.css
@@ -190,8 +190,7 @@ body {
   color: var(--text-primary);
 }
 
-.settings-toggle span,
-#theme-toggle-icon {
+.settings-toggle span {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -200,10 +199,27 @@ body {
   line-height: 1;
 }
 
-#theme-toggle-icon svg {
+#theme-toggle-icon {
   display: block;
-  width: 14px;
-  height: 14px;
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+  background-color: currentcolor;
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -webkit-mask: url("theme-auto.svg") center / contain no-repeat;
+  mask: url("theme-auto.svg") center / contain no-repeat;
+}
+
+html[data-theme-pref="light"] #theme-toggle-icon {
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -webkit-mask-image: url("theme-light.svg");
+  mask-image: url("theme-light.svg");
+}
+
+html[data-theme-pref="dark"] #theme-toggle-icon {
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -webkit-mask-image: url("theme-dark.svg");
+  mask-image: url("theme-dark.svg");
 }
 
 .settings-overlay {

--- a/custom_components/home_intercom/static/intercom.css
+++ b/custom_components/home_intercom/static/intercom.css
@@ -5,10 +5,112 @@
 }
 html, body { height:100%; }
 
+html {
+  background: var(--bg);
+}
+
+:root {
+  color-scheme: dark;
+
+  --bg: #0f0f0f;
+  --fg: #fff;
+  --text-primary: #ccc;
+  --text-heading: #ddd;
+  --text-secondary: #888;
+  --text-muted: #555;
+  --text-faint: #444;
+  --text-dim: #666;
+  --text-room: #999;
+  --surface: #1a1a1a;
+  --surface-2: #141414;
+  --surface-3: #252525;
+  --surface-hover: #2f2f2f;
+  --surface-replace-hover: #181818;
+  --border: #2a2a2a;
+  --border-2: #333;
+  --border-3: #444;
+  --border-device: #262626;
+  --overlay: rgb(0 0 0 / 55%);
+  --shadow-panel: 0 12px 40px rgb(0 0 0 / 45%);
+  --shadow-ptt: 0 6px 16px rgb(0 0 0 / 30%), inset 0 1px 2px rgb(255 255 255 / 6%);
+  --shadow-ptt-recording: inset 0 4px 14px rgb(0 0 0 / 35%);
+  --accent: #f0a030;
+  --success: #33d17a;
+  --success-ptt: #2a5038;
+  --success-border: rgb(51 209 122 / 40%);
+  --success-border-soft: rgb(51 209 122 / 35%);
+  --success-glow: rgb(51 209 122 / 8%);
+  --success-spin-track: rgb(51 209 122 / 20%);
+  --broadcast-ptt: #503a20;
+  --danger: #e74c3c;
+  --danger-hover: #ff6b5a;
+  --danger-border: #c0392b;
+  --danger-btn-border: #5c2a2a;
+  --danger-btn-bg: #2a1818;
+  --danger-btn-border-hover: #8b3a3a;
+  --danger-btn-bg-hover: #3a2020;
+  --danger-btn-disabled: #7a4038;
+  --danger-btn-border-disabled: #3a2222;
+  --danger-btn-bg-disabled: #221515;
+  --insecure-bg: #2a1a1a;
+  --dot-idle: #444;
+  --icon-bar: #666;
+  --theme-color: #0f0f0f;
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
+
+  --bg: #f3f3f4;
+  --fg: #161616;
+  --text-primary: #2c2c2c;
+  --text-heading: #1a1a1a;
+  --text-secondary: #5c5c5c;
+  --text-muted: #6e6e6e;
+  --text-faint: #9a9a9a;
+  --text-dim: #7a7a7a;
+  --text-room: #4a4a4a;
+  --surface: #fff;
+  --surface-2: #f7f7f8;
+  --surface-3: #ececee;
+  --surface-hover: #e2e2e5;
+  --surface-replace-hover: #f0f0f2;
+  --border: #e2e2e4;
+  --border-2: #d4d4d6;
+  --border-3: #c4c4c8;
+  --border-device: #e6e6e8;
+  --overlay: rgb(20 20 20 / 40%);
+  --shadow-panel: 0 12px 40px rgb(0 0 0 / 16%);
+  --shadow-ptt: 0 6px 16px rgb(0 0 0 / 12%), inset 0 1px 2px rgb(255 255 255 / 80%);
+  --shadow-ptt-recording: inset 0 4px 14px rgb(0 0 0 / 12%);
+  --accent: #c47a08;
+  --success: #1a9d53;
+  --success-ptt: #cfe9d8;
+  --success-border: rgb(26 157 83 / 45%);
+  --success-border-soft: rgb(26 157 83 / 40%);
+  --success-glow: rgb(26 157 83 / 10%);
+  --success-spin-track: rgb(26 157 83 / 25%);
+  --broadcast-ptt: #f3dfc0;
+  --danger: #c0392b;
+  --danger-hover: #e74c3c;
+  --danger-border: #c0392b;
+  --danger-btn-border: #f0c4c0;
+  --danger-btn-bg: #fdecea;
+  --danger-btn-border-hover: #e8a8a2;
+  --danger-btn-bg-hover: #fad9d5;
+  --danger-btn-disabled: #c9a09a;
+  --danger-btn-border-disabled: #ead8d6;
+  --danger-btn-bg-disabled: #f7f0ef;
+  --insecure-bg: #fdecea;
+  --dot-idle: #c4c4c8;
+  --icon-bar: #9a9a9a;
+  --theme-color: #f3f3f4;
+}
+
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  background: #0f0f0f;
-  color: #fff;
+  background: var(--bg);
+  color: var(--fg);
   touch-action: manipulation;
   -webkit-touch-callout: none;
   user-select: none;
@@ -32,7 +134,7 @@ body {
 .header h1 {
   font-size: 1rem;
   font-weight: 600;
-  color: #ccc;
+  color: var(--text-primary);
   letter-spacing: 0.02em;
   line-height: 1.25rem;
   min-height: 1.25rem;
@@ -40,7 +142,7 @@ body {
 
 .header .hint {
   font-size: 0.8rem;
-  color: #555;
+  color: var(--text-muted);
   margin-top: 8px;
   line-height: 1.2rem;
   min-height: 2.4rem;
@@ -62,10 +164,13 @@ body {
   flex-shrink: 0;
 }
 
-.settings-toggle {
+.settings-toggle,
+.theme-toggle {
   background: transparent;
   border: none;
-  color: #888;
+  padding: 0;
+  margin: 0;
+  color: var(--text-secondary);
   width: 28px;
   height: 28px;
   display: inline-flex;
@@ -74,17 +179,37 @@ body {
   cursor: pointer;
   font-size: 0.85rem;
   line-height: 1;
+  flex-shrink: 0;
+  appearance: none;
   transition: color 0.2s;
 }
 
-.settings-toggle:hover {
-  color: #ccc;
+.settings-toggle:hover,
+.theme-toggle:hover,
+.theme-dropdown.open .theme-toggle {
+  color: var(--text-primary);
+}
+
+.settings-toggle span,
+#theme-toggle-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  line-height: 1;
+}
+
+#theme-toggle-icon svg {
+  display: block;
+  width: 14px;
+  height: 14px;
 }
 
 .settings-overlay {
   position: fixed;
   inset: 0;
-  background: rgb(0 0 0 / 55%);
+  background: var(--overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -98,11 +223,11 @@ body {
 
 .settings-panel {
   width: min(100%, 360px);
-  background: #1a1a1a;
-  border: 1px solid #2a2a2a;
+  background: var(--surface);
+  border: 1px solid var(--border);
   border-radius: 16px;
   padding: 18px 16px 16px;
-  box-shadow: 0 12px 40px rgb(0 0 0 / 45%);
+  box-shadow: var(--shadow-panel);
 }
 
 .settings-header {
@@ -116,13 +241,13 @@ body {
 .settings-header h2 {
   font-size: 0.95rem;
   font-weight: 600;
-  color: #ddd;
+  color: var(--text-heading);
 }
 
 .settings-close {
   background: transparent;
   border: none;
-  color: #888;
+  color: var(--text-secondary);
   font-size: 1.4rem;
   line-height: 1;
   width: 28px;
@@ -131,7 +256,7 @@ body {
 }
 
 .settings-close:hover {
-  color: #ccc;
+  color: var(--text-primary);
 }
 
 .chime-section {
@@ -141,13 +266,13 @@ body {
 .chime-heading h3 {
   font-size: 0.85rem;
   font-weight: 600;
-  color: #ddd;
+  color: var(--text-heading);
   margin-bottom: 4px;
 }
 
 .chime-desc {
   font-size: 0.72rem;
-  color: #666;
+  color: var(--text-dim);
   margin-bottom: 14px;
   line-height: 1.4;
 }
@@ -156,8 +281,8 @@ body {
   display: flex;
   align-items: flex-start;
   gap: 12px;
-  background: #141414;
-  border: 1px solid #2a2a2a;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
   border-radius: 12px;
   padding: 12px;
   margin-bottom: 10px;
@@ -168,9 +293,9 @@ body {
   width: 36px;
   height: 36px;
   border-radius: 50%;
-  border: 1px solid #333;
-  background: #252525;
-  color: #ccc;
+  border: 1px solid var(--border-2);
+  background: var(--surface-3);
+  color: var(--text-primary);
   font-size: 0.75rem;
   cursor: pointer;
   padding: 0;
@@ -197,9 +322,9 @@ body {
 }
 
 .chime-play-btn:hover {
-  background: #2f2f2f;
-  border-color: #444;
-  color: #fff;
+  background: var(--surface-hover);
+  border-color: var(--border-3);
+  color: var(--fg);
 }
 
 .chime-card-info {
@@ -209,7 +334,7 @@ body {
 
 .chime-filename {
   font-size: 0.78rem;
-  color: #ddd;
+  color: var(--text-heading);
   font-weight: 500;
   white-space: nowrap;
   overflow: hidden;
@@ -219,7 +344,7 @@ body {
 
 .chime-meta {
   font-size: 0.68rem;
-  color: #666;
+  color: var(--text-dim);
   margin-bottom: 8px;
 }
 
@@ -233,8 +358,8 @@ body {
   display: flex;
   align-items: center;
   gap: 12px;
-  background: #141414;
-  border: 1px dashed #333;
+  background: var(--surface-2);
+  border: 1px dashed var(--border-2);
   border-radius: 12px;
   padding: 12px;
   margin-bottom: 14px;
@@ -243,8 +368,8 @@ body {
 }
 
 .chime-replace-card:hover {
-  border-color: #444;
-  background: #181818;
+  border-color: var(--border-3);
+  background: var(--surface-replace-hover);
 }
 
 .chime-replace-icon {
@@ -252,13 +377,13 @@ body {
   width: 36px;
   height: 36px;
   border-radius: 50%;
-  border: 1px solid #333;
+  border: 1px solid var(--border-2);
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 1.1rem;
-  color: #888;
-  background: #252525;
+  color: var(--text-secondary);
+  background: var(--surface-3);
 }
 
 .chime-replace-text {
@@ -270,13 +395,13 @@ body {
 
 .chime-replace-text > span:first-child {
   font-size: 0.78rem;
-  color: #ccc;
+  color: var(--text-primary);
   font-weight: 500;
 }
 
 .chime-replace-hint {
   font-size: 0.65rem;
-  color: #555;
+  color: var(--text-muted);
 }
 
 .chime-footer {
@@ -287,7 +412,7 @@ body {
 .chime-reset-btn {
   background: transparent;
   border: none;
-  color: #e74c3c;
+  color: var(--danger);
   font-size: 0.72rem;
   padding: 4px 0;
   cursor: pointer;
@@ -295,7 +420,7 @@ body {
 }
 
 .chime-reset-btn:hover:not(:disabled) {
-  color: #ff6b5a;
+  color: var(--danger-hover);
 }
 
 .chime-reset-btn:disabled {
@@ -310,10 +435,10 @@ body {
 }
 
 .settings-btn {
-  background: #252525;
-  border: 1px solid #333;
+  background: var(--surface-3);
+  border: 1px solid var(--border-2);
   border-radius: 999px;
-  color: #ccc;
+  color: var(--text-primary);
   font-size: 0.72rem;
   padding: 8px 14px;
   cursor: pointer;
@@ -321,9 +446,9 @@ body {
 }
 
 .settings-btn:hover:not(:disabled) {
-  background: #2f2f2f;
-  color: #fff;
-  border-color: #444;
+  background: var(--surface-hover);
+  color: var(--fg);
+  border-color: var(--border-3);
 }
 
 .settings-btn:disabled {
@@ -332,25 +457,25 @@ body {
 }
 
 .settings-btn-muted {
-  color: #888;
+  color: var(--text-secondary);
 }
 
 .settings-btn-danger {
-  color: #e74c3c;
-  border-color: #5c2a2a;
-  background: #2a1818;
+  color: var(--danger);
+  border-color: var(--danger-btn-border);
+  background: var(--danger-btn-bg);
 }
 
 .settings-btn-danger:hover:not(:disabled) {
-  color: #ff6b5a;
-  border-color: #8b3a3a;
-  background: #3a2020;
+  color: var(--danger-hover);
+  border-color: var(--danger-btn-border-hover);
+  background: var(--danger-btn-bg-hover);
 }
 
 .settings-btn-danger:disabled {
-  color: #7a4038;
-  border-color: #3a2222;
-  background: #221515;
+  color: var(--danger-btn-disabled);
+  border-color: var(--danger-btn-border-disabled);
+  background: var(--danger-btn-bg-disabled);
 }
 
 .chime-upload-label {
@@ -363,48 +488,69 @@ body {
   min-height: 1.2em;
   margin-top: 12px;
   font-size: 0.72rem;
-  color: #f0a030;
+  color: var(--accent);
 }
 
 .footer .ver {
   font-size: 0.7rem;
-  color: #444;
+  color: var(--text-faint);
   letter-spacing: 0.08em;
 }
 
-.lang-dropdown {
+.lang-dropdown,
+.theme-dropdown {
   position: relative;
   flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  height: 28px;
+}
+
+.theme-dropdown {
+  width: 28px;
+}
+
+.lang-dropdown {
+  width: 64px;
+}
+
+.theme-dropdown .lang-dropdown-menu {
+  min-width: 96px;
 }
 
 #lang-toggle {
   background: transparent;
   border: none;
   border-radius: 0;
-  color: #888;
+  padding: 0 7px;
+  margin: 0;
+  appearance: none;
+  color: var(--text-secondary);
   font-size: 0.65rem;
   width: 64px;
   min-width: 64px;
   height: 28px;
-  padding: 0 8px;
   display: inline-flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 4px;
   cursor: pointer;
   letter-spacing: 0.1em;
   text-transform: uppercase;
+  white-space: nowrap;
   transition: color 0.2s;
 }
 
 #lang-toggle-label {
   flex: 1;
-  text-align: center;
+  min-width: 0;
+  text-align: left;
+  white-space: nowrap;
 }
 
 #lang-toggle:hover,
 .lang-dropdown.open #lang-toggle {
-  color: #ccc;
+  color: var(--text-primary);
 }
 
 .lang-chevron {
@@ -417,7 +563,8 @@ body {
   flex-shrink: 0;
 }
 
-.lang-dropdown.open .lang-chevron {
+.lang-dropdown.open .lang-chevron,
+.theme-dropdown.open .lang-chevron {
   transform: rotate(-135deg) translateY(1px);
 }
 
@@ -425,9 +572,9 @@ body {
   position: absolute;
   top: calc(100% + 4px);
   right: 0;
-  min-width: 100%;
-  background: #1a1a1a;
-  border: 1px solid #2a2a2a;
+  min-width: 64px;
+  background: var(--surface);
+  border: 1px solid var(--border);
   z-index: 10;
 }
 
@@ -445,20 +592,21 @@ body {
   width: 100%;
   background: transparent;
   border: none;
-  color: #888;
+  color: var(--text-secondary);
   font-size: 0.65rem;
   padding: 8px 12px;
   text-align: left;
   cursor: pointer;
   letter-spacing: 0.1em;
   text-transform: uppercase;
+  white-space: nowrap;
   transition: background 0.2s, color 0.2s;
 }
 
 .lang-option:hover,
 .lang-option.active {
-  background: #252525;
-  color: #ccc;
+  background: var(--surface-3);
+  color: var(--text-primary);
 }
 
 /* ──── Insecure context banner ──── */
@@ -466,8 +614,8 @@ body {
   display: flex;
   align-items: flex-start;
   gap: 12px;
-  background: #2a1a1a;
-  border: 1px solid #c0392b;
+  background: var(--insecure-bg);
+  border: 1px solid var(--danger-border);
   border-radius: 12px;
   padding: 16px;
   margin-bottom: 10px;
@@ -482,13 +630,13 @@ body {
 .insecure-title {
   font-size: 0.85rem;
   font-weight: 600;
-  color: #e74c3c;
+  color: var(--danger);
   margin-bottom: 4px;
 }
 
 .insecure-hint {
   font-size: 0.75rem;
-  color: #999;
+  color: var(--text-room);
   line-height: 1.4;
 }
 
@@ -529,7 +677,7 @@ body {
   font-size: 30px;
   line-height: 30px;
   font-weight: 600;
-  color: #f0a030;
+  color: var(--accent);
   width: 100%;
 }
 
@@ -585,7 +733,7 @@ body {
 
 /* ──── Room card ──── */
 .room-card {
-  background: #1a1a1a;
+  background: var(--surface);
   border-radius: 20px;
   padding: 16px 12px 14px;
   display: flex;
@@ -595,7 +743,7 @@ body {
   position: relative;
   overflow: hidden;
   transition: background .3s, box-shadow .3s;
-  border: 1px solid #2a2a2a;
+  border: 1px solid var(--border);
 }
 
 .room-card:not(.broadcast-card) {
@@ -620,7 +768,7 @@ body {
 .room-header {
   font-size: 0.9rem;
   font-weight: 500;
-  color: #999;
+  color: var(--text-room);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -657,7 +805,7 @@ body {
 .device-name {
   font-size: 10px;
   line-height: 10px;
-  color: #666;
+  color: var(--text-dim);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -675,19 +823,19 @@ body {
   width: 5px;
   height: 5px;
   border-radius: 50%;
-  background: #444;
+  background: var(--dot-idle);
   transition: background .3s;
 }
 
 /* Dot state classes — used by pollSpeakerStatus + processAndSend */
 .dot-online {
-  background: #33d17a !important;
-  box-shadow: 0 0 4px #33d17a;
+  background: var(--success) !important;
+  box-shadow: 0 0 4px var(--success);
 }
 
 .dot-error {
-  background: #c0392b !important;
-  box-shadow: 0 0 4px #c0392b;
+  background: var(--danger-border) !important;
+  box-shadow: 0 0 4px var(--danger-border);
 }
 
 /* ──── PTT Button ──── */
@@ -701,8 +849,8 @@ body {
   width: 100%; height: 100%;
   border-radius: 50%;
   border: none;
-  background: #252525;
-  box-shadow: 0 6px 16px rgb(0 0 0 / 30%), inset 0 1px 2px rgb(255 255 255 / 6%);
+  background: var(--surface-3);
+  box-shadow: var(--shadow-ptt);
   cursor: pointer;
   position: relative;
   z-index: 2;
@@ -729,7 +877,7 @@ body {
   position: absolute;
   inset: 0;
   border-radius: 50%;
-  border: 2px solid #33d17a;
+  border: 2px solid var(--success);
   opacity: 0;
 }
 
@@ -749,7 +897,7 @@ body {
 
 .ptt-icon span {
   width: 5px;
-  background: #666;
+  background: var(--icon-bar);
   border-radius: 10px;
   transition: background .3s, height .2s;
 }
@@ -767,7 +915,7 @@ body {
   justify-content: center;
   font-size: 3.4rem;
   font-weight: 700;
-  color: #fff;
+  color: var(--fg);
   animation: pop-in .4s cubic-bezier(0.34,1.56,0.64,1);
 }
 
@@ -799,7 +947,7 @@ body {
 /* ──── Status text ──── */
 .status {
   font-size: 0.75rem;
-  color: #555;
+  color: var(--text-muted);
   height: 1.4em;
   line-height: 1.4em;
   text-align: center;
@@ -812,19 +960,19 @@ body {
 
 /* recording */
 .room-card.recording {
-  border-color: rgb(51 209 122 / 40%);
-  box-shadow: 0 0 24px rgb(51 209 122 / 8%);
+  border-color: var(--success-border);
+  box-shadow: 0 0 24px var(--success-glow);
 }
 
 .room-card.recording .ptt-btn {
-  background: #2a5038;
+  background: var(--success-ptt);
   transform: scale(0.95);
-  box-shadow: inset 0 4px 14px rgb(0 0 0 / 35%);
+  box-shadow: var(--shadow-ptt-recording);
 }
-.room-card.recording .status { color: #33d17a; }
+.room-card.recording .status { color: var(--success); }
 
 .room-card.recording .ptt-icon span {
-  background: #33d17a;
+  background: var(--success);
   animation: bounce .6s ease-in-out infinite alternate;
 }
 
@@ -867,16 +1015,16 @@ body {
   cursor: not-allowed;
   pointer-events: none;
 }
-.room-card.unavailable .status { color: #c0392b; }
+.room-card.unavailable .status { color: var(--danger-border); }
 
 /* sending */
 .room-card.sending {
-  border-color: rgb(51 209 122 / 35%);
-  box-shadow: 0 0 24px rgb(51 209 122 / 8%);
+  border-color: var(--success-border-soft);
+  box-shadow: 0 0 24px var(--success-glow);
 }
 
 .room-card.sending .ptt-btn {
-  background: #2a5038;
+  background: var(--success-ptt);
 }
 .room-card.sending .ptt-icon { opacity: 0; }
 .room-card.sending .checkmark { display: none; }
@@ -885,12 +1033,12 @@ body {
   content: "";
   position: absolute;
   inset: -3px;
-  border: 3px solid rgb(51 209 122 / 20%);
-  border-top-color: #33d17a;
+  border: 3px solid var(--success-spin-track);
+  border-top-color: var(--success);
   border-radius: 50%;
   animation: spin .8s linear infinite;
 }
-.room-card.sending .status { color: #f0a030; }
+.room-card.sending .status { color: var(--accent); }
 
 @keyframes spin {
   to { transform: rotate(360deg); }
@@ -898,21 +1046,21 @@ body {
 
 /* sent */
 .room-card.sent {
-  border-color: rgb(51 209 122 / 35%);
+  border-color: var(--success-border-soft);
 }
 
 .room-card.sent .ptt-btn {
-  background: #2a5038;
+  background: var(--success-ptt);
 }
-.room-card.sent .status { color: #33d17a; }
+.room-card.sent .status { color: var(--success); }
 
 /* broadcast card accent */
-.broadcast-card.recording .status { color: #f0a030; }
-.broadcast-card.recording .ptt-btn { background: #503a20; }
-.broadcast-card.sent .ptt-btn { background: #503a20; }
+.broadcast-card.recording .status { color: var(--accent); }
+.broadcast-card.recording .ptt-btn { background: var(--broadcast-ptt); }
+.broadcast-card.sent .ptt-btn { background: var(--broadcast-ptt); }
 
 .broadcast-card .waves::before,
-.broadcast-card .waves::after { border-color: #f0a030; }
+.broadcast-card .waves::after { border-color: var(--accent); }
 
 /* ──── Device list (read-only, issue #52) ──── */
 .devices-section {
@@ -933,14 +1081,14 @@ body {
   min-height: 28px;
   background: none;
   border: none;
-  color: #555;
+  color: var(--text-muted);
   cursor: pointer;
   font: inherit;
   text-align: left;
 }
 
 .devices-toggle:hover {
-  color: #888;
+  color: var(--text-secondary);
 }
 
 .devices-title {
@@ -977,14 +1125,14 @@ body {
   align-items: baseline;
   gap: 10px;
   padding: 8px 12px;
-  background: #1a1a1a;
-  border: 1px solid #262626;
+  background: var(--surface);
+  border: 1px solid var(--border-device);
   border-radius: 10px;
 }
 
 .device-row .device-name {
   font-size: 0.85rem;
-  color: #ddd;
+  color: var(--text-heading);
   flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -993,12 +1141,12 @@ body {
 
 .device-row .device-room {
   font-size: 0.75rem;
-  color: #888;
+  color: var(--text-secondary);
 }
 
 .device-row .device-meta {
   font-size: 0.7rem;
-  color: #555;
+  color: var(--text-muted);
   white-space: nowrap;
 }
 

--- a/custom_components/home_intercom/static/intercom.css
+++ b/custom_components/home_intercom/static/intercom.css
@@ -511,11 +511,21 @@ body {
 }
 
 .lang-dropdown {
-  width: 64px;
+  width: 36px;
 }
 
 .theme-dropdown .lang-dropdown-menu {
   min-width: 96px;
+}
+
+.lang-dropdown .lang-dropdown-menu {
+  min-width: 36px;
+  width: 36px;
+}
+
+.lang-dropdown .lang-option {
+  padding: 8px 7px;
+  text-align: left;
 }
 
 #lang-toggle {
@@ -527,13 +537,12 @@ body {
   appearance: none;
   color: var(--text-secondary);
   font-size: 0.65rem;
-  width: 64px;
-  min-width: 64px;
+  width: 36px;
+  min-width: 36px;
   height: 28px;
   display: inline-flex;
   align-items: center;
   justify-content: flex-start;
-  gap: 4px;
   cursor: pointer;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -553,26 +562,11 @@ body {
   color: var(--text-primary);
 }
 
-.lang-chevron {
-  width: 6px;
-  height: 6px;
-  border-right: 1px solid currentcolor;
-  border-bottom: 1px solid currentcolor;
-  transform: rotate(45deg) translateY(-2px);
-  transition: transform 0.2s;
-  flex-shrink: 0;
-}
-
-.lang-dropdown.open .lang-chevron,
-.theme-dropdown.open .lang-chevron {
-  transform: rotate(-135deg) translateY(1px);
-}
-
 .lang-dropdown-menu {
   position: absolute;
   top: calc(100% + 4px);
   right: 0;
-  min-width: 64px;
+  min-width: 36px;
   background: var(--surface);
   border: 1px solid var(--border);
   z-index: 10;

--- a/custom_components/home_intercom/static/theme-auto.svg
+++ b/custom_components/home_intercom/static/theme-auto.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <circle cx="8" cy="8" r="6" fill="none" stroke="#000" stroke-width="1.5"/>
+  <path fill="#000" d="M8 2a6 6 0 0 0 0 12z"/>
+</svg>

--- a/custom_components/home_intercom/static/theme-dark.svg
+++ b/custom_components/home_intercom/static/theme-dark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <path fill="#000" d="M10.6 2.2a6.2 6.2 0 1 0 3.2 9.2 5.1 5.1 0 0 1-3.2-9.2z"/>
+</svg>

--- a/custom_components/home_intercom/static/theme-light.svg
+++ b/custom_components/home_intercom/static/theme-light.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <circle cx="8" cy="8" r="2.6" fill="#000"/>
+  <path fill="none" stroke="#000" stroke-width="1.5" stroke-linecap="round" d="M8 1.5v1.8M8 12.7v1.8M1.5 8h1.8M12.7 8h1.8M3.3 3.3l1.3 1.3M11.4 11.4l1.3 1.3M3.3 12.7l1.3-1.3M11.4 4.6l1.3-1.3"/>
+</svg>

--- a/tests/test_html_quality.py
+++ b/tests/test_html_quality.py
@@ -163,6 +163,10 @@ class TestHtmlStructure:
         """Theme switcher: auto / light / dark, persisted and FOUC-safe."""
         assert 'id="theme-toggle"' in html_content
         assert 'id="theme-dropdown"' in html_content
+        assert re.search(
+            r'<span id="theme-toggle-icon"[^>]*></span>',
+            html_content,
+        )
         assert 'data-theme-pref="auto"' in html_content
         assert 'data-theme-pref="light"' in html_content
         assert 'data-theme-pref="dark"' in html_content
@@ -307,6 +311,9 @@ class TestDomConsistency:
         assert ':root[data-theme="light"]' in css
         assert "color-scheme: dark" in css
         assert "color-scheme: light" in css
+        assert 'url("theme-auto.svg")' in css
+        assert 'url("theme-light.svg")' in css
+        assert 'url("theme-dark.svg")' in css
 
 
 class TestI18N:
@@ -339,6 +346,13 @@ class TestI18N:
                 f"Key '{key}' appears only {count} time(s) in i18n.js — "
                 f"expected at least 2 (zh-CN + en)"
             )
+
+    def test_theme_icons_not_inlined(self):
+        """Theme glyphs live as static SVG files, not markup inside i18n.js."""
+        with open(I18N_PATH) as f:
+            i18n = f.read()
+        assert "<svg" not in i18n
+        assert "ICONS" not in i18n
 
     def test_html_uses_i18n_t(self, html_content):
         """All user-facing strings in JS should use I18N.t()."""
@@ -390,6 +404,9 @@ class TestManifestAndIcons:
             "apple-touch-icon.png",
             "i18n.js",
             "intercom.css",
+            "theme-auto.svg",
+            "theme-light.svg",
+            "theme-dark.svg",
         ]
         for fname in expected:
             path = os.path.join(static_dir, fname)

--- a/tests/test_html_quality.py
+++ b/tests/test_html_quality.py
@@ -40,6 +40,10 @@ I18N_REQUIRED_KEYS = [
     "chimePreview",
     "chimeUploadOk",
     "chimeUploadFail",
+    "themeTitle",
+    "themeAuto",
+    "themeLight",
+    "themeDark",
 ]
 
 CHINESE_STATUS_STRINGS = [
@@ -154,6 +158,16 @@ class TestHtmlStructure:
         assert 'id="settings-toggle"' in html_content
         assert 'data-lang="zh-CN"' in html_content
         assert 'data-lang="en"' in html_content
+
+    def test_has_theme_toggle(self, html_content):
+        """Theme switcher: auto / light / dark, persisted and FOUC-safe."""
+        assert 'id="theme-toggle"' in html_content
+        assert 'id="theme-dropdown"' in html_content
+        assert 'data-theme-pref="auto"' in html_content
+        assert 'data-theme-pref="light"' in html_content
+        assert 'data-theme-pref="dark"' in html_content
+        assert "intercom-theme" in html_content
+        assert "prefers-color-scheme" in html_content
 
     def test_has_data_i18n_attributes(self, html_content):
         """Broadcast name should use data-i18n, not fragile nth-child selectors."""
@@ -276,6 +290,23 @@ class TestDomConsistency:
             css = f.read()
         assert ".room-card.unavailable" in css
         assert "pointer-events: none" in css
+
+    def test_theme_tokens_exist(self):
+        """Light/dark themes are CSS custom properties, not duplicated palettes in JS."""
+        css_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "custom_components",
+            "home_intercom",
+            "static",
+            "intercom.css",
+        )
+        with open(css_path) as f:
+            css = f.read()
+        assert "--bg:" in css
+        assert ':root[data-theme="light"]' in css
+        assert "color-scheme: dark" in css
+        assert "color-scheme: light" in css
 
 
 class TestI18N:


### PR DESCRIPTION
## Summary
- Add a footer theme control (Auto / Light / Dark); Auto follows `prefers-color-scheme` and updates when the OS theme changes.
- Move PWA colors onto CSS variables with a light palette, and apply the theme before first paint so the page does not flash.
- Tighten the language control (no chevron, 36px toggle and menu) so it stays aligned with settings/theme without shifting the footer.

## Test plan
- [x] Open the PWA, hard-refresh, and confirm Auto matches the browser/OS theme
- [x] Switch Light and Dark from the footer icon; confirm settings panel, PTT cards, and device list all update
- [x] Set Auto, then change the OS/browser color scheme and confirm the PWA follows without reload
- [x] Switch 中文 / EN; confirm the menu is left-aligned, one line, and the footer buttons do not shift
- [x] Confirm language and theme dropdowns close when opening the other, or the settings panel


Made with [Cursor](https://cursor.com)