### PR TITLE
feat: add rooms write API for HA and Docker

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -11,6 +11,7 @@ jobs:
     env:
       AUDIO_DIR: /tmp/audio
       DEVICE_REGISTRY_FILE: /tmp/device_registry.json
+      ROOMS_FILE: /tmp/home_intercom_rooms.json
 
     steps:
       - uses: actions/checkout@v4

--- a/custom_components/home_intercom/api.py
+++ b/custom_components/home_intercom/api.py
@@ -6,7 +6,8 @@ Maps the Flask routes from intercom_server.py to HomeAssistantView:
   /chime         → ChimeView         (GET status; POST/DELETE custom chime via PWA token)
   /rooms/status  → StatusView  (GET speaker online status)
   /version       → VersionView (GET version only)
-  /rooms         → RoomsView   (GET room config)
+  /rooms         → RoomsView       (GET room config)
+  /rooms/{id}    → RoomsItemView   (PUT/PATCH/DELETE via PWA token)
   /devices       → DevicesView        (GET registry)
   /devices/approve → DevicesApproveView
   /devices/manage  → DevicesManageView (approve/deapprove/revoke/unrevoke/delete/ota)
@@ -28,11 +29,13 @@ from homeassistant.components.http import KEY_HASS_USER, HomeAssistantView
 from homeassistant.core import HomeAssistant
 
 from .const import (
+    CONF_ROOMS,
     DOMAIN,
     FIRMWARE_CACHE_SUBDIR,
     PANEL_PATH,
     PANEL_PATH_LEGACY,
     PCM_RATE,
+    UI_UNIQUE_ID,
     WAV_HEADER_SIZE,
 )
 from .firmware import (
@@ -43,6 +46,7 @@ from .firmware import (
     schedule_firmware_refresh,
 )
 from .player import play_announcement
+from .rooms import RoomValidationError, patch_room, put_room, validate_room_key
 from .shared import (
     chime_public_url,
     chime_status_payload,
@@ -200,6 +204,40 @@ def _verify_pwa_token(request: web.Request, *, view: str) -> web.Response | None
         _LOGGER.warning("%s: invalid or missing X-PWA-Token", view)
         return web.json_response({"ok": False, "error": "unauthorized"}, status=401)
     return None
+
+
+def _find_ui_entry(hass: HomeAssistant):
+    """Writable UI config entry (Options Flow store). YAML/buttons are not writable."""
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        if getattr(entry, "unique_id", None) == UI_UNIQUE_ID:
+            return entry
+    return None
+
+
+def _entry_rooms(entry) -> dict:
+    """Combined data + options rooms for one config entry (options win)."""
+    data_rooms = dict(entry.data.get(CONF_ROOMS, {}) or {})
+    options_rooms = dict(entry.options.get(CONF_ROOMS, {}) or {})
+    return {**data_rooms, **options_rooms}
+
+
+def _persist_ui_rooms(hass: HomeAssistant, entry, rooms: dict) -> dict:
+    """Save rooms on the UI entry and refresh the merged in-memory map.
+
+    ``async_update_entry`` triggers the options update listener → reload,
+    which rebuilds room devices. In-memory state is updated immediately so
+    GET /rooms matches the write response without waiting for reload.
+    """
+    options = dict(entry.options)
+    options[CONF_ROOMS] = rooms
+    hass.config_entries.async_update_entry(entry, options=options)
+    data = _get_hass_data(hass)
+    data.setdefault("entry_rooms", {})[entry.entry_id] = rooms
+    merged: dict = {}
+    for room_map in data.get("entry_rooms", {}).values():
+        merged.update(room_map)
+    data["rooms"] = merged
+    return merged
 
 
 def _remove_button_ha_device(hass: HomeAssistant, mac: str) -> None:
@@ -396,6 +434,71 @@ class RoomsView(HomeAssistantView):
 
     async def get(self, request: web.Request) -> web.Response:
         return web.json_response(_get_hass_data(request.app["hass"]).get("rooms", {}))
+
+
+class RoomsItemView(HomeAssistantView):
+    """PUT/PATCH/DELETE /api/home_intercom/rooms/{id} — PWA room writes (#72)."""
+
+    url = "/api/home_intercom/rooms/{room_id}"
+    name = "api:home_intercom:rooms-item"
+    requires_auth = False  # auth via X-PWA-Token header
+
+    async def put(self, request: web.Request, room_id: str) -> web.Response:
+        return await _rooms_write(request, room_id, method="PUT")
+
+    async def patch(self, request: web.Request, room_id: str) -> web.Response:
+        return await _rooms_write(request, room_id, method="PATCH")
+
+    async def delete(self, request: web.Request, room_id: str) -> web.Response:
+        return await _rooms_write(request, room_id, method="DELETE")
+
+
+async def _rooms_write(request: web.Request, room_id: str, *, method: str) -> web.Response:
+    """Mutate one room on the UI config entry and persist immediately."""
+    denied = _verify_pwa_token(request, view="RoomsItemView")
+    if denied is not None:
+        return denied
+    try:
+        key = validate_room_key(room_id)
+    except RoomValidationError as exc:
+        return web.json_response({"ok": False, "error": str(exc)}, status=400)
+
+    hass = request.app["hass"]
+    entry = _find_ui_entry(hass)
+    if entry is None:
+        return web.json_response({"ok": False, "error": "no writable config entry"}, status=409)
+
+    ui_rooms = _entry_rooms(entry)
+    merged = _get_hass_data(hass).get("rooms", {})
+
+    if method == "DELETE":
+        if key not in ui_rooms:
+            if key in merged:
+                return web.json_response({"ok": False, "error": "yaml_read_only"}, status=409)
+            return web.json_response({"ok": False, "error": "unknown room"}, status=404)
+        ui_rooms.pop(key)
+        rooms = _persist_ui_rooms(hass, entry, ui_rooms)
+        return web.json_response({"ok": True, "rooms": rooms})
+
+    try:
+        body = await request.json()
+    except Exception:
+        body = None
+    try:
+        if method == "PUT":
+            room = put_room(body, entity_key="entity_id")
+        elif key not in ui_rooms:
+            if key in merged:
+                return web.json_response({"ok": False, "error": "yaml_read_only"}, status=409)
+            return web.json_response({"ok": False, "error": "unknown room"}, status=404)
+        else:
+            room = patch_room(ui_rooms[key], body, entity_key="entity_id")
+    except RoomValidationError as exc:
+        return web.json_response({"ok": False, "error": str(exc)}, status=400)
+
+    ui_rooms[key] = room
+    rooms = _persist_ui_rooms(hass, entry, ui_rooms)
+    return web.json_response({"ok": True, "rooms": rooms})
 
 
 class DevicesHelloView(HomeAssistantView):
@@ -764,6 +867,7 @@ def register_api_views(hass: HomeAssistant) -> None:
     hass.http.register_view(VersionView)
     hass.http.register_view(ConfigView)
     hass.http.register_view(RoomsView)
+    hass.http.register_view(RoomsItemView)
     hass.http.register_view(DevicesHelloView)
     hass.http.register_view(DevicesApproveView)
     hass.http.register_view(DevicesManageView)

--- a/custom_components/home_intercom/const.py
+++ b/custom_components/home_intercom/const.py
@@ -35,6 +35,7 @@ DEVICE_NAME_PREFIX = "Device"  # auto-register: "Device EE:FF"
 DEVICE_UPDATEABLE_FIELDS = frozenset({"name", "room", "revoked", "pending"})
 MAC_PATTERN = r"^([0-9A-F]{2}:){5}[0-9A-F]{2}$"  # normalized uppercase form
 DEVICE_REGISTRY_DEFAULT_PATH = "/data/device_registry.json"  # Docker default
+ROOMS_STORE_DEFAULT = "/data/rooms.json"  # Docker writable room catalog (#72)
 MAX_RECORD_SECS = 60  # recording cap delivered to ESP32 via hello/config
 # ESP32 hellos every 10s while idle; 30s ≈ three missed heartbeats.
 DEVICE_ONLINE_WINDOW_SECS = 30

--- a/custom_components/home_intercom/rooms.py
+++ b/custom_components/home_intercom/rooms.py
@@ -1,0 +1,193 @@
+"""Room catalog helpers shared by HA and Docker (issue #72).
+
+GET /rooms stays a public map. Writes validate the same payload on both
+deployments, then persist in the native shape:
+
+- HA config entries: ``name`` + ``entity_id``
+- Docker ``/data/rooms.json``: ``name`` + ``entity``
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import re
+from typing import Any, Literal
+
+try:
+    from .const import CONF_ANNOUNCE_VOLUME, CONF_PAUSE_BUFFER
+except ImportError:
+    from const import CONF_ANNOUNCE_VOLUME, CONF_PAUSE_BUFFER
+
+_LOGGER = logging.getLogger(__name__)
+
+ROOM_KEY_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$")
+ENTITY_RE = re.compile(r"^media_player\.[a-z0-9_]+$")
+RESERVED_ROOM_KEYS = frozenset({"all", "status"})
+MAX_ROOM_NAME_LEN = 64
+MAX_PAUSE_BUFFER = 10.0
+
+EntityKey = Literal["entity", "entity_id"]
+
+
+class RoomValidationError(ValueError):
+    """Invalid room key or body. ``str(exc)`` is safe to return to the client."""
+
+
+def validate_room_key(room_id: str) -> str:
+    """Return a trimmed room key or raise RoomValidationError."""
+    key = (room_id or "").strip()
+    if not key or not ROOM_KEY_RE.match(key) or key.lower() in RESERVED_ROOM_KEYS:
+        raise RoomValidationError("invalid room id")
+    return key
+
+
+def room_entity(room: dict[str, Any]) -> str:
+    """Media player id from either Docker (``entity``) or HA (``entity_id``)."""
+    return str(room.get("entity_id") or room.get("entity") or "").strip()
+
+
+def _parse_name(value: Any) -> str:
+    if not isinstance(value, str):
+        raise RoomValidationError("invalid name")
+    name = value.strip()
+    if not name or len(name) > MAX_ROOM_NAME_LEN:
+        raise RoomValidationError("invalid name")
+    return name
+
+
+def _parse_entity(body: dict[str, Any]) -> str | None:
+    if "entity_id" not in body and "entity" not in body:
+        return None
+    raw = body.get("entity_id", body.get("entity"))
+    if not isinstance(raw, str):
+        raise RoomValidationError("invalid entity")
+    entity = raw.strip().lower()
+    if not ENTITY_RE.match(entity):
+        raise RoomValidationError("invalid entity")
+    return entity
+
+
+def _parse_announce_volume(value: Any) -> int | None:
+    """Return 1–100, or None to omit/clear. 0 and null clear."""
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise RoomValidationError("invalid announce_volume")
+    volume = int(value)
+    if volume == 0:
+        return None
+    if volume < 1 or volume > 100:
+        raise RoomValidationError("invalid announce_volume")
+    return volume
+
+
+def _parse_pause_buffer(value: Any) -> float | None:
+    """Return >0 seconds, or None to omit/clear. 0 and null clear."""
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise RoomValidationError("invalid pause_buffer")
+    buf = float(value)
+    if buf == 0:
+        return None
+    if buf < 0 or buf > MAX_PAUSE_BUFFER:
+        raise RoomValidationError("invalid pause_buffer")
+    return buf
+
+
+def _apply_optional(room: dict[str, Any], body: dict[str, Any], *, replace: bool) -> None:
+    if replace or CONF_ANNOUNCE_VOLUME in body:
+        volume = _parse_announce_volume(body.get(CONF_ANNOUNCE_VOLUME))
+        if volume is None:
+            room.pop(CONF_ANNOUNCE_VOLUME, None)
+        else:
+            room[CONF_ANNOUNCE_VOLUME] = volume
+    if replace or CONF_PAUSE_BUFFER in body:
+        buf = _parse_pause_buffer(body.get(CONF_PAUSE_BUFFER))
+        if buf is None:
+            room.pop(CONF_PAUSE_BUFFER, None)
+        else:
+            room[CONF_PAUSE_BUFFER] = buf
+
+
+def put_room(body: Any, *, entity_key: EntityKey) -> dict[str, Any]:
+    """Build a full room record for PUT (create or replace)."""
+    if not isinstance(body, dict):
+        raise RoomValidationError("invalid body")
+    name = _parse_name(body.get("name"))
+    entity = _parse_entity(body)
+    if entity is None:
+        raise RoomValidationError("missing entity")
+    room: dict[str, Any] = {"name": name, entity_key: entity}
+    _apply_optional(room, body, replace=True)
+    return room
+
+
+def patch_room(existing: dict[str, Any], body: Any, *, entity_key: EntityKey) -> dict[str, Any]:
+    """Merge PATCH fields into an existing room."""
+    if not isinstance(body, dict):
+        raise RoomValidationError("invalid body")
+    known = {"name", "entity", "entity_id", CONF_ANNOUNCE_VOLUME, CONF_PAUSE_BUFFER}
+    if not any(key in body for key in known):
+        raise RoomValidationError("empty patch")
+    room = dict(existing)
+    if "name" in body:
+        room["name"] = _parse_name(body.get("name"))
+    entity = _parse_entity(body)
+    if entity is not None:
+        other = "entity_id" if entity_key == "entity" else "entity"
+        room.pop(other, None)
+        room[entity_key] = entity
+    _apply_optional(room, body, replace=False)
+    return room
+
+
+def load_rooms(store_path: str, seed_path: str) -> dict[str, Any]:
+    """Load the writable store, seeding from the bundled file when missing."""
+    if os.path.isfile(store_path):
+        rooms = _read_rooms_file(store_path)
+        _LOGGER.info("rooms loaded from %s (%d)", store_path, len(rooms))
+        return rooms
+    rooms = _read_rooms_file(seed_path) if os.path.isfile(seed_path) else {}
+    try:
+        save_rooms(store_path, rooms)
+        _LOGGER.info("rooms seeded %s → %s (%d)", seed_path, store_path, len(rooms))
+    except OSError as exc:
+        _LOGGER.warning("could not seed rooms store %s: %s", store_path, exc)
+    return rooms
+
+
+def save_rooms(path: str, rooms: dict[str, Any]) -> None:
+    """Persist rooms JSON. Falls back to in-place write if os.replace fails."""
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    payload = json.dumps(rooms, indent=2, ensure_ascii=False) + "\n"
+    tmp_path = f"{path}.tmp"
+    try:
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            f.write(payload)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, path)
+        return
+    except OSError:
+        with contextlib.suppress(OSError):
+            os.remove(tmp_path)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(payload)
+        f.flush()
+        os.fsync(f.fileno())
+
+
+def _read_rooms_file(path: str) -> dict[str, Any]:
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        _LOGGER.error("Failed to load rooms %s: %s", path, exc)
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {str(key): value for key, value in data.items() if isinstance(value, dict)}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,7 @@ COPY custom_components/home_intercom/const.py ./
 COPY custom_components/home_intercom/shared.py ./
 COPY custom_components/home_intercom/auto_pause.py ./
 COPY custom_components/home_intercom/firmware.py ./
+COPY custom_components/home_intercom/rooms.py ./
 COPY custom_components/home_intercom/intercom.html ./
 COPY custom_components/home_intercom/static/ ./static/
 

--- a/docker/docker-compose.example.yml
+++ b/docker/docker-compose.example.yml
@@ -4,13 +4,13 @@ services:
     container_name: home-intercom
     restart: unless-stopped
     volumes:
-      # Persist device registry + firmware cache. Mount a *directory*, not
-      # the JSON file — file bind-mounts cannot be atomically replaced (EBUSY).
+      # Persist device registry, firmware cache, and rooms.json. Mount a
+      # *directory*, not a JSON file — file bind-mounts cannot be atomically
+      # replaced (EBUSY). Live rooms live at /data/rooms.json (seeded from
+      # the image on first start).
       - ./data:/data
       # Audio files served by Flask (no SCP)
       - ./audio:/data/audio
-      # rooms.json editable without rebuild
-      - ../src/rooms.json:/app/rooms.json:ro
     environment:
       - HA_URL=http://<YOUR_HA_IP>:8123
       - HA_TOKEN=<YOUR_HA_LONG_LIVED_TOKEN>

--- a/src/ha_client.py
+++ b/src/ha_client.py
@@ -371,6 +371,7 @@ class HAClient:
         audio_url_with_chime: str | None = None,
         duration_with_chime: float | None = None,
         chime_url: str | None = None,
+        pause_buffer: float | None = None,
     ) -> dict:
         """Play audio — tiers: MA announcement > modern announce > basic + timer.
 
@@ -408,7 +409,13 @@ class HAClient:
         url = audio_url_with_chime or audio_url
         dur = duration_with_chime or duration
         return self._play_standard(
-            entity_id, url, dur, info, announce_volume=announce_volume, info_ok=info_ok
+            entity_id,
+            url,
+            dur,
+            info,
+            announce_volume=announce_volume,
+            info_ok=info_ok,
+            pause_buffer=pause_buffer,
         )
 
     def _play_ma_announcement(
@@ -459,6 +466,7 @@ class HAClient:
         info: dict,
         announce_volume: int | None = None,
         info_ok: bool = True,
+        pause_buffer: float | None = None,
     ) -> dict:
         """Tier 2/3: standard media_player — guard, optional volume boost, play."""
         if not self._has_play_media(info):
@@ -477,6 +485,7 @@ class HAClient:
         _logger.info(
             f"[intercom] {entity_id} modern={modern} (features=0x{info['supported_features']:x})"
         )
+        buf = self._pause_buffer if pause_buffer is None else float(pause_buffer)
 
         # Volume boost: save current → set announce volume → restore after playback
         saved_volume: float | None = None
@@ -500,7 +509,7 @@ class HAClient:
             if saved_volume is not None:
                 threading.Thread(
                     target=self._volume_restore_bg,
-                    args=(entity_id, saved_volume, duration),
+                    args=(entity_id, saved_volume, duration, buf),
                     daemon=True,
                 ).start()
             return {"ok": True}
@@ -508,7 +517,7 @@ class HAClient:
         # Basic player: pause timer + volume restore
         threading.Thread(
             target=self._auto_pause_bg,
-            args=(entity_id, duration, saved_volume),
+            args=(entity_id, duration, saved_volume, buf),
             daemon=True,
         ).start()
         return {"ok": True}
@@ -542,12 +551,25 @@ class HAClient:
             _logger.info(f"[intercom] {entity_id} restoring volume to {saved_volume:.2f}")
             self._set_volume_level(entity_id, saved_volume)
 
-    def _volume_restore_bg(self, entity_id: str, saved_volume: float, wait_sec: float):
+    def _volume_restore_bg(
+        self,
+        entity_id: str,
+        saved_volume: float,
+        wait_sec: float,
+        pause_buffer: float | None = None,
+    ):
         """Background thread: wait for modern player to finish, then restore volume."""
-        time.sleep(wait_sec + self._pause_buffer)
+        buf = self._pause_buffer if pause_buffer is None else pause_buffer
+        time.sleep(wait_sec + buf)
         self._restore_volume(entity_id, saved_volume)
 
-    def _auto_pause_bg(self, entity_id: str, wait_sec: float, saved_volume: float | None = None):
+    def _auto_pause_bg(
+        self,
+        entity_id: str,
+        wait_sec: float,
+        saved_volume: float | None = None,
+        pause_buffer: float | None = None,
+    ):
         """Background thread: confirm playback → wait → pause + verify, then restore volume."""
         ws = self._ws
         use_ws = ws is not None and ws.ready
@@ -582,7 +604,12 @@ class HAClient:
                 return ws.wait_for_state(eid, None, timeout)
 
         try:
-            run_auto_pause(entity_id, wait_sec, self._pause_buffer, _RestBackend())
+            run_auto_pause(
+                entity_id,
+                wait_sec,
+                self._pause_buffer if pause_buffer is None else pause_buffer,
+                _RestBackend(),
+            )
         finally:
             self._restore_volume(entity_id, saved_volume)
 
@@ -597,7 +624,7 @@ class HAClient:
         """
         status = {}
         for key, room in room_map.items():
-            entity = room.get("entity", "")
+            entity = room.get("entity") or room.get("entity_id") or ""
             if not entity:
                 status[key] = {"status": EntityStatus.ONLINE, "friendly_name": ""}
                 continue

--- a/src/intercom_server.py
+++ b/src/intercom_server.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
 """Home Intercom — PWA-based family broadcast system backend."""
 
-import json
 import os
 import sys
 from pathlib import Path
 
-from const import DEVICE_REGISTRY_DEFAULT_PATH, FIRMWARE_DIR_DEFAULT, PCM_RATE, WAV_HEADER_SIZE
+from const import (
+    DEVICE_REGISTRY_DEFAULT_PATH,
+    FIRMWARE_DIR_DEFAULT,
+    PCM_RATE,
+    ROOMS_STORE_DEFAULT,
+    WAV_HEADER_SIZE,
+)
 from firmware import (
     FirmwareError,
     ensure_latest_firmware,
@@ -16,6 +21,15 @@ from firmware import (
     start_firmware_poller,
 )
 from flask import Flask, jsonify, request, send_from_directory
+from rooms import (
+    RoomValidationError,
+    load_rooms,
+    patch_room,
+    put_room,
+    room_entity,
+    save_rooms,
+    validate_room_key,
+)
 from shared import (
     chime_public_url,
     chime_status_payload,
@@ -87,10 +101,10 @@ try:
 except Exception:
     VERSION = os.environ.get("VERSION", "dev")
 
-# Load room config from rooms.json
-ROOMS_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "rooms.json")
-with open(ROOMS_FILE) as f:
-    ROOM_MAP = json.load(f)
+# Writable room catalog (#72). Bundled rooms.json is seed only.
+ROOMS_STORE = os.environ.get("ROOMS_FILE", ROOMS_STORE_DEFAULT)
+ROOMS_SEED = os.path.join(os.path.dirname(os.path.abspath(__file__)), "rooms.json")
+ROOM_MAP = load_rooms(ROOMS_STORE, ROOMS_SEED)
 
 # Device registry for ESP32 intercom buttons (issue #40)
 DEVICE_REGISTRY_FILE = os.environ.get("DEVICE_REGISTRY_FILE", DEVICE_REGISTRY_DEFAULT_PATH)
@@ -104,13 +118,57 @@ def index():
 
 
 @app.route("/rooms.json")
-def rooms_json():
-    return send_from_directory(os.path.dirname(os.path.abspath(__file__)), "rooms.json")
-
-
 @app.route("/rooms")
 def rooms_alias():
-    return send_from_directory(os.path.dirname(os.path.abspath(__file__)), "rooms.json")
+    """Public room map (issue #38). Live catalog, not the image-baked seed file."""
+    return jsonify(ROOM_MAP)
+
+
+def _persist_room_map():
+    """Write ROOM_MAP to the Docker store. Raises OSError if the path is not writable."""
+    save_rooms(ROOMS_STORE, ROOM_MAP)
+
+
+@app.route("/rooms/<room_id>", methods=["PUT", "PATCH", "DELETE"])
+def rooms_item(room_id):
+    """Create, update, or delete one room. LAN trust, same as /chime POST (#72)."""
+    try:
+        key = validate_room_key(room_id)
+    except RoomValidationError as exc:
+        return jsonify({"ok": False, "error": str(exc)}), 400
+
+    if request.method == "DELETE":
+        if key not in ROOM_MAP:
+            return jsonify({"ok": False, "error": "unknown room"}), 404
+        removed = ROOM_MAP.pop(key)
+        try:
+            _persist_room_map()
+        except OSError:
+            ROOM_MAP[key] = removed
+            return jsonify({"ok": False, "error": "cannot persist rooms"}), 500
+        return jsonify({"ok": True, "rooms": ROOM_MAP})
+
+    body = request.get_json(silent=True)
+    try:
+        if request.method == "PUT":
+            room = put_room(body, entity_key="entity")
+        elif key not in ROOM_MAP:
+            return jsonify({"ok": False, "error": "unknown room"}), 404
+        else:
+            room = patch_room(ROOM_MAP[key], body, entity_key="entity")
+    except RoomValidationError as exc:
+        return jsonify({"ok": False, "error": str(exc)}), 400
+    previous = ROOM_MAP.get(key)
+    ROOM_MAP[key] = room
+    try:
+        _persist_room_map()
+    except OSError:
+        if previous is None:
+            ROOM_MAP.pop(key, None)
+        else:
+            ROOM_MAP[key] = previous
+        return jsonify({"ok": False, "error": "cannot persist rooms"}), 500
+    return jsonify({"ok": True, "rooms": ROOM_MAP})
 
 
 @app.route("/static/<path:filename>")
@@ -272,12 +330,12 @@ def record():
         return jsonify({"ok": False, "error": "missing target"}), 400
 
     if target == "all":
-        targets = [(k, v) for k, v in ROOM_MAP.items() if v.get("entity")]
+        targets = [(k, v) for k, v in ROOM_MAP.items() if room_entity(v)]
         if not targets:
             return jsonify({"ok": False, "error": "no rooms configured"}), 500
     else:
         room = ROOM_MAP.get(target)
-        if not room or not room.get("entity"):
+        if not room or not room_entity(room):
             return jsonify({"ok": False, "error": f"unknown target: {target}"}), 400
         targets = [(target, room)]
 
@@ -309,20 +367,22 @@ def record():
     ok_count = 0
     errors = []
     for _tgt_key, tgt_room in targets:
+        entity = room_entity(tgt_room)
         announce_volume = tgt_room.get("announce_volume")
         result = haclient.play_announcement(
-            tgt_room["entity"],
+            entity,
             audio_url,
             duration,
             announce_volume=announce_volume,
             audio_url_with_chime=audio_url_with_chime,
             duration_with_chime=duration_with_chime,
             chime_url=chime_url,
+            pause_buffer=tgt_room.get("pause_buffer"),
         )
         if result["ok"]:
             ok_count += 1
         else:
-            errors.append({"entity": tgt_room["entity"], "error": result.get("error", "unknown")})
+            errors.append({"entity": entity, "error": result.get("error", "unknown")})
 
     name = ROOM_MAP[target]["name"] if target != "all" else "全部"
     app.logger.info(f"[intercom] played on {ok_count}/{len(targets)} rooms for {name}")
@@ -417,6 +477,12 @@ app.add_url_rule(
 )
 app.add_url_rule(f"{_HA_PREFIX}/devices", "ha_devices", devices_list)
 app.add_url_rule(f"{_HA_PREFIX}/rooms", "ha_rooms", rooms_alias)
+app.add_url_rule(
+    f"{_HA_PREFIX}/rooms/<room_id>",
+    "ha_rooms_item",
+    rooms_item,
+    methods=["PUT", "PATCH", "DELETE"],
+)
 app.add_url_rule(f"{_HA_PREFIX}/rooms/status", "ha_rooms_status", rooms_status)
 app.add_url_rule(f"{_HA_PREFIX}/version", "ha_version", version)
 app.add_url_rule(f"{_HA_PREFIX}/config", "ha_config", config)
@@ -442,6 +508,7 @@ if __name__ == "__main__":
     print(f"[intercom] HA URL: {HA_URL}", flush=True)
     print(f"[intercom] Audio dir: {AUDIO_DIR}", flush=True)
     print(f"[intercom] Firmware dir: {FIRMWARE_DIR}", flush=True)
+    print(f"[intercom] Rooms store: {ROOMS_STORE} ({len(ROOM_MAP)} rooms)", flush=True)
     print(f"[intercom] Trusted proxy: {trusted_proxy}", flush=True)
     print("[intercom] Starting on http://0.0.0.0:8764", flush=True)
     start_firmware_poller(FIRMWARE_DIR, should_run=lambda: bool(device_store.devices))

--- a/tests/docker-smoke/run.sh
+++ b/tests/docker-smoke/run.sh
@@ -136,12 +136,14 @@ fi
 TMPDIR=$(mktemp -d)
 EXPECTED_ROOMS='{"test":{"name":"Test Room","entity":"media_player.test_speaker"}}'
 echo "${EXPECTED_ROOMS}" > "${TMPDIR}/rooms.json"
+mkdir -p "${TMPDIR}/data"
 
 # ── Start container ─────────────────────────────────────────
 echo "==> Starting intercom container..."
 docker run -d \
     --name "${CONTAINER_NAME}" \
     -v "${TMPDIR}/rooms.json:/app/rooms.json:ro" \
+    -v "${TMPDIR}/data:/data" \
     -p "${PORT}:${PORT}" \
     -e HA_URL="http://ha:8123" \
     -e HA_TOKEN="fake-token" \
@@ -193,6 +195,43 @@ got = json.load(sys.stdin)
 expected = json.loads('${EXPECTED_ROOMS}')
 assert got == expected, f'mismatch\\n  got:      {json.dumps(got)}\\n  expected: {json.dumps(expected)}'
 print('ok: rooms match input')
+"
+
+# 2b. PUT/PATCH/DELETE /rooms/<id> — writable catalog (issue #72)
+PUT=$(fetch -X PUT -H "Content-Type: application/json" \
+    -d '{"name":"Office","entity":"media_player.office","announce_volume":40}' \
+    "${URL}/rooms/office" || echo "")
+assert_json "PUT /rooms/office" "${PUT}" "
+import sys, json
+d = json.load(sys.stdin)
+assert d.get('ok') is True, f'not ok: {d}'
+assert d['rooms']['office']['entity'] == 'media_player.office'
+print('ok: office created')
+"
+PATCH=$(fetch -X PATCH -H "Content-Type: application/json" \
+    -d '{"name":"Study"}' "${URL}/rooms/office" || echo "")
+assert_json "PATCH /rooms/office" "${PATCH}" "
+import sys, json
+d = json.load(sys.stdin)
+assert d['rooms']['office']['name'] == 'Study', d
+print('ok: renamed')
+"
+assert_ha_alias "PUT /api/home_intercom/rooms/office — matches /rooms after write" \
+    "$(fetch "${URL}/rooms" || echo "")" "/api/home_intercom/rooms"
+DEL=$(fetch -X DELETE "${URL}/rooms/office" || echo "")
+assert_json "DELETE /rooms/office" "${DEL}" "
+import sys, json
+d = json.load(sys.stdin)
+assert 'office' not in d.get('rooms', {}), d
+print('ok: office removed')
+"
+ROOMS=$(fetch "${URL}/rooms" || echo "")
+assert_json "GET /rooms — seed rooms remain after delete" "${ROOMS}" "
+import sys, json
+got = json.load(sys.stdin)
+expected = json.loads('${EXPECTED_ROOMS}')
+assert got == expected, f'mismatch\\n  got:      {json.dumps(got)}\\n  expected: {json.dumps(expected)}'
+print('ok: rooms restored to seed')
 "
 
 # 3. / — PWA frontend

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,6 +18,8 @@ from .ha_fakes import install_fake_homeassistant
 # ——— Fake homeassistant package before any custom_components imports ———
 install_fake_homeassistant()
 
+from custom_components.home_intercom.const import CONF_ROOMS, UI_UNIQUE_ID  # noqa: E402
+
 # ——— Test data ———
 
 WAV_DATA = (
@@ -54,21 +56,38 @@ def _make_hass(rooms: dict | None = None) -> MagicMock:
 
     audio_dir = tempfile.mkdtemp(prefix="hi_test_audio_")
 
+    room_map = (
+        rooms
+        if rooms is not None
+        else {
+            "living_room": {
+                "name": "Living Room",
+                "entity_id": "media_player.living_speaker",
+                "announce_volume": 50,
+            },
+            "bedroom": {
+                "name": "Bedroom",
+                "entity_id": "media_player.bedroom_speaker",
+            },
+        }
+    )
+    rooms_copy = {key: dict(value) for key, value in room_map.items()}
+    ui_entry = MagicMock()
+    ui_entry.unique_id = UI_UNIQUE_ID
+    ui_entry.entry_id = "ui-entry"
+    ui_entry.data = {CONF_ROOMS: {key: dict(value) for key, value in rooms_copy.items()}}
+    ui_entry.options = {}
+
+    def _update_entry(entry, **kwargs):
+        if "options" in kwargs:
+            entry.options = kwargs["options"]
+
+    hass.config_entries.async_entries.return_value = [ui_entry]
+    hass.config_entries.async_update_entry.side_effect = _update_entry
     hass.data = {
         "home_intercom": {
-            "rooms": rooms
-            if rooms is not None
-            else {
-                "living_room": {
-                    "name": "Living Room",
-                    "entity_id": "media_player.living_speaker",
-                    "announce_volume": 50,
-                },
-                "bedroom": {
-                    "name": "Bedroom",
-                    "entity_id": "media_player.bedroom_speaker",
-                },
-            },
+            "rooms": rooms_copy,
+            "entry_rooms": {"ui-entry": {key: dict(value) for key, value in rooms_copy.items()}},
             "audio_dir": audio_dir,
             "pwa_token": PWA_TOKEN,
         },
@@ -648,6 +667,7 @@ class TestRegisterApiViews:
             PanelAliasView,
             PanelView,
             RecordView,
+            RoomsItemView,
             StaticAliasView,
             StaticView,
             register_api_views,
@@ -658,6 +678,7 @@ class TestRegisterApiViews:
         register_api_views(hass)
         calls = [c.args[0] for c in hass.http.register_view.call_args_list]
         assert RecordView in calls
+        assert RoomsItemView in calls
         assert ChimeView in calls
         assert DeviceRecordView in calls
         assert DevicesApproveView in calls
@@ -753,6 +774,116 @@ class TestRoomsView:
         resp = await RoomsView().get(req)
         assert resp.status == 200
         assert json.loads(resp.text) == {}
+
+
+class TestRoomsItemView:
+    """PUT/PATCH/DELETE /api/home_intercom/rooms/{id} (issue #72)."""
+
+    def _req(
+        self,
+        token: str | None,
+        body: dict | None = None,
+        *,
+        hass: MagicMock | None = None,
+    ) -> MagicMock:
+        req = _make_request()
+        req.app = {"hass": hass or _make_hass()}
+        req.headers = {"X-PWA-Token": token} if token else {}
+        req.json = AsyncMock(return_value=body if body is not None else {})
+        return req
+
+    @pytest.mark.asyncio
+    async def test_put_creates_room(self):
+        from custom_components.home_intercom.api import RoomsItemView, RoomsView
+
+        hass = _make_hass()
+        req = self._req(
+            PWA_TOKEN,
+            {"name": "Study", "entity_id": "media_player.study"},
+            hass=hass,
+        )
+        resp = await RoomsItemView().put(req, "study")
+        assert resp.status == 200
+        body = json.loads(resp.text)
+        assert body["ok"] is True
+        assert body["rooms"]["study"]["entity_id"] == "media_player.study"
+        get_req = _make_request()
+        get_req.app = {"hass": hass}
+        got = json.loads((await RoomsView().get(get_req)).text)
+        assert "study" in got
+
+    @pytest.mark.asyncio
+    async def test_patch_updates_name(self):
+        from custom_components.home_intercom.api import RoomsItemView
+
+        hass = _make_hass()
+        req = self._req(PWA_TOKEN, {"name": "Lounge"}, hass=hass)
+        resp = await RoomsItemView().patch(req, "living_room")
+        assert resp.status == 200
+        room = json.loads(resp.text)["rooms"]["living_room"]
+        assert room["name"] == "Lounge"
+        assert room["entity_id"] == "media_player.living_speaker"
+
+    @pytest.mark.asyncio
+    async def test_delete_removes_room(self):
+        from custom_components.home_intercom.api import RoomsItemView
+
+        hass = _make_hass()
+        req = self._req(PWA_TOKEN, hass=hass)
+        resp = await RoomsItemView().delete(req, "bedroom")
+        assert resp.status == 200
+        assert "bedroom" not in json.loads(resp.text)["rooms"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_missing_token(self):
+        from custom_components.home_intercom.api import RoomsItemView
+
+        req = self._req(None, {"name": "Study", "entity": "media_player.study"})
+        resp = await RoomsItemView().put(req, "study")
+        assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_invalid_room_id(self):
+        from custom_components.home_intercom.api import RoomsItemView
+
+        req = self._req(PWA_TOKEN, {"name": "X", "entity_id": "media_player.x"})
+        resp = await RoomsItemView().put(req, "all")
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_no_ui_entry_conflict(self):
+        from custom_components.home_intercom.api import RoomsItemView
+        from custom_components.home_intercom.const import YAML_UNIQUE_ID
+
+        hass = _make_hass()
+        yaml_entry = MagicMock()
+        yaml_entry.unique_id = YAML_UNIQUE_ID
+        yaml_entry.entry_id = "yaml-entry"
+        hass.config_entries.async_entries.return_value = [yaml_entry]
+        req = self._req(PWA_TOKEN, {"name": "Study", "entity_id": "media_player.study"}, hass=hass)
+        resp = await RoomsItemView().put(req, "study")
+        assert resp.status == 409
+        assert json.loads(resp.text)["error"] == "no writable config entry"
+
+    @pytest.mark.asyncio
+    async def test_yaml_only_room_delete_conflict(self):
+        from custom_components.home_intercom.api import RoomsItemView
+
+        hass = _make_hass(rooms={})
+        ui_entry = hass.config_entries.async_entries.return_value[0]
+        assert ui_entry.unique_id == UI_UNIQUE_ID
+        hass.data["home_intercom"]["entry_rooms"] = {
+            "ui-entry": {},
+            "yaml-entry": {"study": {"name": "Study", "entity_id": "media_player.study_speaker"}},
+        }
+        hass.data["home_intercom"]["rooms"] = {
+            "study": {"name": "Study", "entity_id": "media_player.study_speaker"}
+        }
+        ui_entry.data = {CONF_ROOMS: {}}
+        req = self._req(PWA_TOKEN, hass=hass)
+        resp = await RoomsItemView().delete(req, "study")
+        assert resp.status == 409
+        assert json.loads(resp.text)["error"] == "yaml_read_only"
 
 
 # ——— ChimeView tests (issue #66) ———

--- a/tests/test_ha_client.py
+++ b/tests/test_ha_client.py
@@ -240,7 +240,7 @@ class TestHAClientPlayAndAutoPause:
     def test_play_failure_does_not_spawn_thread(self):
         with (
             patch("ha_client.HAWebSocketClient") as mock_ws,
-            patch("ha_client.threading.Thread") as mock_thread_class,
+            patch("threading.Thread.start"),
         ):
             mock_ws.return_value.ready = False
             client = HAClient("http://ha:8123", "tok")
@@ -250,11 +250,13 @@ class TestHAClientPlayAndAutoPause:
                 "urllib.request.urlopen",
                 side_effect=urllib.error.HTTPError("url", 500, "err", {}, None),
             ),
-            patch("ha_client.threading.Thread") as mock_thread_class,
+            patch.object(client, "_auto_pause_bg") as mock_pause,
+            patch.object(client, "_volume_restore_bg") as mock_restore,
         ):
             result = client.play_announcement("media_player.test", "http://ha/audio/test.wav", 2.0)
 
-        mock_thread_class.assert_not_called()
+        mock_pause.assert_not_called()
+        mock_restore.assert_not_called()
         assert result == {"ok": False, "error": "play_failed"}
 
 

--- a/tests/test_intercom_server.py
+++ b/tests/test_intercom_server.py
@@ -55,6 +55,72 @@ class TestStaticRoutes:
         assert resp.status_code == 404
 
 
+class TestRoomsWrite:
+    """PUT/PATCH/DELETE /rooms/<id> (issue #72)."""
+
+    @pytest.fixture
+    def rooms_client(self, client, monkeypatch, tmp_path):
+        import copy
+
+        import intercom_server
+
+        monkeypatch.setattr(intercom_server, "ROOMS_STORE", str(tmp_path / "rooms.json"))
+        monkeypatch.setattr(intercom_server, "ROOM_MAP", copy.deepcopy(intercom_server.ROOM_MAP))
+        return client
+
+    def test_put_creates_and_get_reflects(self, rooms_client):
+        resp = rooms_client.put(
+            "/rooms/office",
+            json={"name": "Office", "entity": "media_player.office", "announce_volume": 40},
+        )
+        assert resp.status_code == 200
+        assert resp.json["ok"] is True
+        assert resp.json["rooms"]["office"]["entity"] == "media_player.office"
+        got = rooms_client.get("/rooms").json
+        assert got["office"]["name"] == "Office"
+
+    def test_put_ha_alias(self, rooms_client):
+        resp = rooms_client.put(
+            "/api/home_intercom/rooms/office",
+            json={"name": "Office", "entity_id": "media_player.office"},
+        )
+        assert resp.status_code == 200
+        assert rooms_client.get("/rooms").json["office"]["entity"] == "media_player.office"
+
+    def test_patch_and_delete(self, rooms_client):
+        rooms_client.put("/rooms/office", json={"name": "Office", "entity": "media_player.office"})
+        patched = rooms_client.patch("/rooms/office", json={"name": "Study", "pause_buffer": 1.5})
+        assert patched.status_code == 200
+        room = patched.json["rooms"]["office"]
+        assert room["name"] == "Study"
+        assert room["pause_buffer"] == 1.5
+        deleted = rooms_client.delete("/rooms/office")
+        assert deleted.status_code == 200
+        assert "office" not in deleted.json["rooms"]
+        assert rooms_client.delete("/rooms/office").status_code == 404
+
+    def test_rejects_reserved_id(self, rooms_client):
+        resp = rooms_client.put("/rooms/all", json={"name": "All", "entity": "media_player.x"})
+        assert resp.status_code == 400
+
+    def test_patch_unknown(self, rooms_client):
+        resp = rooms_client.patch("/rooms/mars", json={"name": "Mars"})
+        assert resp.status_code == 404
+
+    def test_persist_error_is_500(self, rooms_client, monkeypatch):
+        import intercom_server
+
+        def _boom():
+            raise OSError("ebusy")
+
+        monkeypatch.setattr(intercom_server, "_persist_room_map", _boom)
+        resp = rooms_client.put(
+            "/rooms/office", json={"name": "Office", "entity": "media_player.office"}
+        )
+        assert resp.status_code == 500
+        assert resp.json["error"] == "cannot persist rooms"
+
+
 class TestDevicesRoute:
     """GET /devices + HA alias — read-only registry listing (issue #52)."""
 

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -1,0 +1,106 @@
+"""Unit tests for room catalog helpers (issue #72)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from rooms import (
+    RoomValidationError,
+    load_rooms,
+    patch_room,
+    put_room,
+    room_entity,
+    save_rooms,
+    validate_room_key,
+)
+
+
+class TestValidateRoomKey:
+    def test_accepts_slug(self) -> None:
+        assert validate_room_key("living_room") == "living_room"
+
+    def test_rejects_reserved(self) -> None:
+        with pytest.raises(RoomValidationError, match="invalid room id"):
+            validate_room_key("all")
+        with pytest.raises(RoomValidationError, match="invalid room id"):
+            validate_room_key("status")
+
+    def test_rejects_empty(self) -> None:
+        with pytest.raises(RoomValidationError, match="invalid room id"):
+            validate_room_key(" ")
+
+
+class TestPutPatch:
+    def test_put_docker_entity(self) -> None:
+        room = put_room(
+            {"name": "Study", "entity": "media_player.study", "announce_volume": 40},
+            entity_key="entity",
+        )
+        assert room == {
+            "name": "Study",
+            "entity": "media_player.study",
+            "announce_volume": 40,
+        }
+
+    def test_put_accepts_entity_id_alias(self) -> None:
+        room = put_room(
+            {"name": "Study", "entity_id": "media_player.study"},
+            entity_key="entity",
+        )
+        assert room["entity"] == "media_player.study"
+        assert "entity_id" not in room
+
+    def test_put_omits_zero_optionals(self) -> None:
+        room = put_room(
+            {
+                "name": "Study",
+                "entity_id": "media_player.study",
+                "announce_volume": 0,
+                "pause_buffer": 0,
+            },
+            entity_key="entity_id",
+        )
+        assert room == {"name": "Study", "entity_id": "media_player.study"}
+
+    def test_put_requires_name_and_entity(self) -> None:
+        with pytest.raises(RoomValidationError, match="missing entity"):
+            put_room({"name": "Study"}, entity_key="entity_id")
+
+    def test_patch_clears_volume(self) -> None:
+        existing = {
+            "name": "Study",
+            "entity_id": "media_player.study",
+            "announce_volume": 50,
+        }
+        room = patch_room(existing, {"announce_volume": None}, entity_key="entity_id")
+        assert "announce_volume" not in room
+        assert room["name"] == "Study"
+
+    def test_patch_empty_rejected(self) -> None:
+        with pytest.raises(RoomValidationError, match="empty patch"):
+            patch_room({"name": "A", "entity": "media_player.a"}, {}, entity_key="entity")
+
+    def test_room_entity_reads_both_keys(self) -> None:
+        assert room_entity({"entity": "media_player.a"}) == "media_player.a"
+        assert room_entity({"entity_id": "media_player.b"}) == "media_player.b"
+
+
+class TestLoadSave:
+    def test_seeds_when_store_missing(self, tmp_path: Path) -> None:
+        seed = tmp_path / "seed.json"
+        seed.write_text(json.dumps({"living": {"name": "Living", "entity": "media_player.x"}}))
+        store = tmp_path / "data" / "rooms.json"
+        rooms = load_rooms(str(store), str(seed))
+        assert "living" in rooms
+        saved = json.loads(store.read_text())
+        assert saved["living"]["name"] == "Living"
+
+    def test_store_wins_over_seed(self, tmp_path: Path) -> None:
+        seed = tmp_path / "seed.json"
+        seed.write_text(json.dumps({"old": {"name": "Old", "entity": "media_player.a"}}))
+        store = tmp_path / "rooms.json"
+        save_rooms(str(store), {"new": {"name": "New", "entity": "media_player.b"}})
+        rooms = load_rooms(str(store), str(seed))
+        assert list(rooms) == ["new"]


### PR DESCRIPTION
## Summary
- `PUT`/`PATCH`/`DELETE` `/rooms/{id}` (and `/api/home_intercom/rooms/{id}`) create, update, and delete rooms without editing YAML or `rooms.json`. `GET /rooms` is unchanged.
- HA writes persist on the UI config entry options (same store as Options Flow) and refresh the in-memory catalog immediately. YAML-only rooms return `409`; missing UI entry is `409`. Auth matches `/chime` (PWA token).
- Docker persists to `/data/rooms.json` (seeded from the bundled file). Compose mounts a data directory instead of a read-only `rooms.json` file. Per-room `pause_buffer` is stored and used on playback.
- Closes #72.

## Test plan
- [x] Unit tests for validation, HA views, and Flask routes; docker-smoke PUT/PATCH/DELETE.
- [x] NAS Docker: GET kept the five live rooms; PUT/PATCH/DELETE `api_test` worked without restart; host `/data/rooms.json` updated.
- [x] HA: PUT a room with PWA token, GET `/api/home_intercom/rooms` includes it, Options Flow / entities pick it up after reload.
- [x] YAML-only room DELETE returns `409 yaml_read_only`.
- [x] PWA still only reads `/rooms` (#74 UI not in this PR).


Made with [Cursor](https://cursor.com)