### PR TITLE
feat: add media player catalog endpoint for the room picker

### DIFF
--- a/custom_components/home_intercom/api.py
+++ b/custom_components/home_intercom/api.py
@@ -8,6 +8,7 @@ Maps the Flask routes from intercom_server.py to HomeAssistantView:
   /version       → VersionView (GET version only)
   /rooms         → RoomsView       (GET room config)
   /rooms/{id}    → RoomsItemView   (PUT/PATCH/DELETE via PWA token)
+  /media_players  → MediaPlayersView (GET play_media speakers)
   /devices       → DevicesView        (GET registry)
   /devices/approve → DevicesApproveView
   /devices/manage  → DevicesManageView (approve/deapprove/revoke/unrevoke/delete/ota)
@@ -45,6 +46,7 @@ from .firmware import (
     load_cached_firmware,
     schedule_firmware_refresh,
 )
+from .media_players import media_player_catalog
 from .player import play_announcement
 from .rooms import RoomValidationError, patch_room, put_room, validate_room_key
 from .shared import (
@@ -501,6 +503,17 @@ async def _rooms_write(request: web.Request, room_id: str, *, method: str) -> we
     return web.json_response({"ok": True, "rooms": rooms})
 
 
+class MediaPlayersView(HomeAssistantView):
+    """GET /api/home_intercom/media_players — play_media speakers for the PWA picker (#73)."""
+
+    url = "/api/home_intercom/media_players"
+    name = "api:home_intercom:media-players"
+    requires_auth = False  # public like GET /rooms; names only, no secrets
+
+    async def get(self, request: web.Request) -> web.Response:
+        return web.json_response(media_player_catalog(request.app["hass"]))
+
+
 class DevicesHelloView(HomeAssistantView):
     """POST /api/home_intercom/devices/hello — ESP32 boot registration (issue #37).
 
@@ -868,6 +881,7 @@ def register_api_views(hass: HomeAssistant) -> None:
     hass.http.register_view(ConfigView)
     hass.http.register_view(RoomsView)
     hass.http.register_view(RoomsItemView)
+    hass.http.register_view(MediaPlayersView)
     hass.http.register_view(DevicesHelloView)
     hass.http.register_view(DevicesApproveView)
     hass.http.register_view(DevicesManageView)

--- a/custom_components/home_intercom/config_flow.py
+++ b/custom_components/home_intercom/config_flow.py
@@ -32,6 +32,7 @@ from .const import (
     UI_UNIQUE_ID,
     YAML_UNIQUE_ID,
 )
+from .media_players import media_player_catalog
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,39 +42,9 @@ _LOGGER = logging.getLogger(__name__)
 # ═══════════════════════════════════════════════════════════════════════
 
 
-# SUPPORT_PLAY_MEDIA = 1 << 9 (MediaPlayerEntityFeature.PLAY_MEDIA)
-_PLAY_MEDIA = 1 << 9
-
-
 def _media_player_choices(hass):
-    """Return {entity_id: friendly_name} for media_player entities that support play_media.
-
-    Sorted by area name, then friendly_name. Entities without an area sort last.
-    """
-    from homeassistant.helpers import area_registry as ar
-    from homeassistant.helpers import entity_registry as er
-
-    er_reg = er.async_get(hass)
-    ar_reg = ar.async_get(hass)
-
-    entries: list[
-        tuple[str, str, str, str]
-    ] = []  # (area_key, friendly_key, entity_id, friendly_display)
-    for state in hass.states.async_all("media_player"):
-        supported = state.attributes.get("supported_features", 0)
-        if not (supported & _PLAY_MEDIA):
-            continue
-        friendly = state.attributes.get("friendly_name") or state.entity_id
-        area_name = "\uffff"  # sort entities without area last
-        e_entry = er_reg.async_get(state.entity_id)
-        if e_entry and e_entry.area_id:
-            area = ar_reg.async_get_area(e_entry.area_id)
-            if area and area.name:
-                area_name = area.name.strip()
-        entries.append((area_name.lower(), friendly.lower(), state.entity_id, friendly))
-
-    entries.sort(key=lambda e: (e[0], e[1]))
-    return {e[2]: e[3] for e in entries}
+    """Return {entity_id: friendly_name} for media_player entities that support play_media."""
+    return {entry["entity_id"]: entry["name"] for entry in media_player_catalog(hass)}
 
 
 def _area_choices(hass):

--- a/custom_components/home_intercom/media_players.py
+++ b/custom_components/home_intercom/media_players.py
@@ -1,0 +1,33 @@
+"""HA media_player catalog for the PWA picker (issue #73).
+
+Kept out of config_flow.py so api.py can import it without loading ConfigFlow
+(unit tests use a fake homeassistant package).
+"""
+
+from __future__ import annotations
+
+from .rooms import PLAY_MEDIA, sort_media_player_catalog
+
+
+def media_player_catalog(hass) -> list[dict[str, str]]:
+    """Players that support play_media, sorted by area then name."""
+    from homeassistant.helpers import area_registry as ar
+    from homeassistant.helpers import entity_registry as er
+
+    er_reg = er.async_get(hass)
+    ar_reg = ar.async_get(hass)
+
+    entries: list[dict[str, str]] = []
+    for state in hass.states.async_all("media_player"):
+        supported = state.attributes.get("supported_features", 0) or 0
+        if not (supported & PLAY_MEDIA):
+            continue
+        friendly = state.attributes.get("friendly_name") or state.entity_id
+        area_name = ""
+        e_entry = er_reg.async_get(state.entity_id)
+        if e_entry and e_entry.area_id:
+            area = ar_reg.async_get_area(e_entry.area_id)
+            if area and area.name:
+                area_name = area.name.strip()
+        entries.append({"entity_id": state.entity_id, "name": str(friendly), "area": area_name})
+    return sort_media_player_catalog(entries)

--- a/custom_components/home_intercom/rooms.py
+++ b/custom_components/home_intercom/rooms.py
@@ -28,6 +28,8 @@ ENTITY_RE = re.compile(r"^media_player\.[a-z0-9_]+$")
 RESERVED_ROOM_KEYS = frozenset({"all", "status"})
 MAX_ROOM_NAME_LEN = 64
 MAX_PAUSE_BUFFER = 10.0
+# MediaPlayerEntityFeature.PLAY_MEDIA — same bit Options Flow uses.
+PLAY_MEDIA = 1 << 9
 
 EntityKey = Literal["entity", "entity_id"]
 
@@ -143,6 +145,43 @@ def patch_room(existing: dict[str, Any], body: Any, *, entity_key: EntityKey) ->
         room[entity_key] = entity
     _apply_optional(room, body, replace=False)
     return room
+
+
+def sort_media_player_catalog(entries: list[dict[str, str]]) -> list[dict[str, str]]:
+    """Sort by area name, then friendly name. Players without an area sort last."""
+
+    def key(entry: dict[str, str]) -> tuple[str, str, str]:
+        area = (entry.get("area") or "").strip()
+        area_key = area.lower() if area else "\uffff"
+        return (area_key, (entry.get("name") or "").lower(), entry.get("entity_id") or "")
+
+    return sorted(entries, key=key)
+
+
+def catalog_from_ha_states(states: Any) -> list[dict[str, str]]:
+    """Build GET /media_players from HA REST ``GET /api/states``.
+
+    Area is empty: the REST state payload does not include the area registry.
+    """
+    if not isinstance(states, list):
+        return []
+    entries: list[dict[str, str]] = []
+    for state in states:
+        if not isinstance(state, dict):
+            continue
+        entity_id = str(state.get("entity_id") or "")
+        if not entity_id.startswith("media_player."):
+            continue
+        attrs = state.get("attributes") if isinstance(state.get("attributes"), dict) else {}
+        try:
+            supported = int(attrs.get("supported_features") or 0)
+        except (TypeError, ValueError):
+            supported = 0
+        if not (supported & PLAY_MEDIA):
+            continue
+        name = str(attrs.get("friendly_name") or entity_id)
+        entries.append({"entity_id": entity_id, "name": name, "area": ""})
+    return sort_media_player_catalog(entries)
 
 
 def load_rooms(store_path: str, seed_path: str) -> dict[str, Any]:

--- a/src/ha_client.py
+++ b/src/ha_client.py
@@ -309,6 +309,23 @@ class HAClient:
             )
         return ok
 
+    def media_player_catalog(self) -> list[dict]:
+        """media_player entities that support play_media (issue #73).
+
+        Uses REST ``GET /api/states``. Area is always empty — that lives in
+        the entity registry, which this client does not query.
+        """
+        from rooms import catalog_from_ha_states
+
+        if not self._token:
+            return []
+        timeout = max(self._state_timeout, 15)
+        code, result = self._request("GET", "/states", timeout=timeout)
+        if code != 200 or not isinstance(result, list):
+            _logger.warning("[intercom] media_player catalog failed: HTTP %s", code or result)
+            return []
+        return catalog_from_ha_states(result)
+
     def supports_repeat_set(self, entity_id: str) -> bool:
         """Check if entity supports repeat_set — used as modernity proxy.
 

--- a/src/intercom_server.py
+++ b/src/intercom_server.py
@@ -222,6 +222,12 @@ def rooms_status():
     return jsonify(haclient.query_statuses(ROOM_MAP))
 
 
+@app.route("/media_players")
+def media_players():
+    """HA media_player entities that support play_media (issue #73). Public like GET /rooms."""
+    return jsonify(haclient.media_player_catalog())
+
+
 @app.route("/version")
 def version():
     return jsonify({"version": VERSION})
@@ -484,6 +490,7 @@ app.add_url_rule(
     methods=["PUT", "PATCH", "DELETE"],
 )
 app.add_url_rule(f"{_HA_PREFIX}/rooms/status", "ha_rooms_status", rooms_status)
+app.add_url_rule(f"{_HA_PREFIX}/media_players", "ha_media_players", media_players)
 app.add_url_rule(f"{_HA_PREFIX}/version", "ha_version", version)
 app.add_url_rule(f"{_HA_PREFIX}/config", "ha_config", config)
 app.add_url_rule(f"{_HA_PREFIX}/record", "ha_record", record, methods=["POST"])

--- a/tests/docker-smoke/run.sh
+++ b/tests/docker-smoke/run.sh
@@ -187,6 +187,16 @@ print(f'ok: config={d}')
 "
 assert_ha_alias "GET /api/home_intercom/config — matches /config" "${CFG}" "/api/home_intercom/config"
 
+# 1d. GET /media_players — catalog is a JSON array (empty when HA is unreachable)
+PLAYERS=$(fetch "${URL}/media_players" || echo "")
+assert_json "GET /media_players — JSON array" "${PLAYERS}" "
+import sys, json
+d = json.load(sys.stdin)
+assert isinstance(d, list), f'expected list, got: {d}'
+print(f'ok: n={len(d)}')
+"
+assert_ha_alias "GET /api/home_intercom/media_players — matches /media_players" "${PLAYERS}" "/api/home_intercom/media_players"
+
 # 2. /rooms — verify matches input rooms.json
 ROOMS=$(fetch "${URL}/rooms" || echo "")
 assert_json "GET /rooms — matches input" "${ROOMS}" "

--- a/tests/smoke/run.sh
+++ b/tests/smoke/run.sh
@@ -188,6 +188,17 @@ else
     exit 1
 fi
 
+# 2b. /api/home_intercom/media_players — JSON array (issue #73)
+PLAYERS=$(docker exec "${CONTAINER_NAME}" \
+    curl -sS "http://localhost:${HA_PORT}/api/home_intercom/media_players" 2>/dev/null || echo "")
+if echo "${PLAYERS}" | python3 -c "import sys,json; d=json.load(sys.stdin); assert isinstance(d, list)" 2>/dev/null; then
+    echo "  ✅ GET /api/home_intercom/media_players — JSON array"
+else
+    echo "  ❌ GET /api/home_intercom/media_players — expected JSON array"
+    echo "     Response: ${PLAYERS}"
+    exit 1
+fi
+
 # 3. /api/home_intercom/rooms/status
 STATUS=$(docker exec "${CONTAINER_NAME}" \
     curl -sS "http://localhost:${HA_PORT}/api/home_intercom/rooms/status" 2>/dev/null || echo "{}")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -664,6 +664,7 @@ class TestRegisterApiViews:
             DevicesManageView,
             FirmwareSigView,
             FirmwareView,
+            MediaPlayersView,
             PanelAliasView,
             PanelView,
             RecordView,
@@ -678,6 +679,7 @@ class TestRegisterApiViews:
         register_api_views(hass)
         calls = [c.args[0] for c in hass.http.register_view.call_args_list]
         assert RecordView in calls
+        assert MediaPlayersView in calls
         assert RoomsItemView in calls
         assert ChimeView in calls
         assert DeviceRecordView in calls
@@ -774,6 +776,80 @@ class TestRoomsView:
         resp = await RoomsView().get(req)
         assert resp.status == 200
         assert json.loads(resp.text) == {}
+
+
+class TestMediaPlayersView:
+    """GET /api/home_intercom/media_players (issue #73)."""
+
+    def test_class_attributes(self):
+        from custom_components.home_intercom.api import MediaPlayersView
+
+        assert MediaPlayersView.url == "/api/home_intercom/media_players"
+        assert MediaPlayersView.requires_auth is False
+
+    @pytest.mark.asyncio
+    async def test_get_returns_catalog(self):
+        from custom_components.home_intercom.api import MediaPlayersView
+
+        catalog = [{"entity_id": "media_player.study", "name": "Study", "area": "Study"}]
+        req = _make_request()
+        req.app = {"hass": _make_hass()}
+        with patch(
+            "custom_components.home_intercom.api.media_player_catalog", return_value=catalog
+        ):
+            resp = await MediaPlayersView().get(req)
+        assert resp.status == 200
+        assert json.loads(resp.text) == catalog
+
+    def test_catalog_filters_and_area(self):
+        from custom_components.home_intercom.media_players import media_player_catalog
+        from custom_components.home_intercom.rooms import PLAY_MEDIA
+
+        play = MagicMock()
+        play.entity_id = "media_player.kitchen"
+        play.attributes = {"friendly_name": "Kitchen Speaker", "supported_features": PLAY_MEDIA}
+        skip = MagicMock()
+        skip.entity_id = "media_player.dead"
+        skip.attributes = {"friendly_name": "Dead", "supported_features": 0}
+        hass = MagicMock()
+        hass.states.async_all.return_value = [play, skip]
+        ent = MagicMock()
+        ent.area_id = "kitchen"
+        er_reg = MagicMock()
+        er_reg.async_get.return_value = ent
+        area = MagicMock()
+        area.name = "Kitchen"
+        ar_reg = MagicMock()
+        ar_reg.async_get_area.return_value = area
+        with (
+            patch("homeassistant.helpers.entity_registry.async_get", return_value=er_reg),
+            patch("homeassistant.helpers.area_registry.async_get", return_value=ar_reg),
+        ):
+            catalog = media_player_catalog(hass)
+        assert catalog == [
+            {"entity_id": "media_player.kitchen", "name": "Kitchen Speaker", "area": "Kitchen"}
+        ]
+
+    def test_catalog_empty_area_and_entity_id_fallback(self):
+        from custom_components.home_intercom.media_players import media_player_catalog
+        from custom_components.home_intercom.rooms import PLAY_MEDIA
+
+        player = MagicMock()
+        player.entity_id = "media_player.study"
+        player.attributes = {"supported_features": PLAY_MEDIA}
+        hass = MagicMock()
+        hass.states.async_all.return_value = [player]
+        er_reg = MagicMock()
+        er_reg.async_get.return_value = None
+        ar_reg = MagicMock()
+        with (
+            patch("homeassistant.helpers.entity_registry.async_get", return_value=er_reg),
+            patch("homeassistant.helpers.area_registry.async_get", return_value=ar_reg),
+        ):
+            catalog = media_player_catalog(hass)
+        assert catalog == [
+            {"entity_id": "media_player.study", "name": "media_player.study", "area": ""}
+        ]
 
 
 class TestRoomsItemView:

--- a/tests/test_ha_client.py
+++ b/tests/test_ha_client.py
@@ -81,6 +81,35 @@ class TestHAClientRequest:
         assert "no route" in result
 
 
+class TestHAClientMediaPlayerCatalog:
+    def test_filters_play_media(self):
+        from rooms import PLAY_MEDIA
+
+        client = HAClient("http://ha:8123", "tok")
+        payload = [
+            {
+                "entity_id": "media_player.study",
+                "attributes": {"friendly_name": "Study", "supported_features": PLAY_MEDIA},
+            },
+            {
+                "entity_id": "media_player.dead",
+                "attributes": {"friendly_name": "Dead", "supported_features": 0},
+            },
+        ]
+        with patch.object(client, "_request", return_value=(200, payload)):
+            catalog = client.media_player_catalog()
+        assert catalog == [{"entity_id": "media_player.study", "name": "Study", "area": ""}]
+
+    def test_empty_without_token(self):
+        client = HAClient("http://ha:8123", "")
+        assert client.media_player_catalog() == []
+
+    def test_ha_error_returns_empty(self):
+        client = HAClient("http://ha:8123", "tok")
+        with patch.object(client, "_request", return_value=(500, "HTTP 500")):
+            assert client.media_player_catalog() == []
+
+
 class TestHAClientState:
     def test_returns_state_string(self):
         client = HAClient("http://ha:8123", "tok")

--- a/tests/test_intercom_server.py
+++ b/tests/test_intercom_server.py
@@ -487,6 +487,27 @@ class TestConfigRoute:
         assert resp.json == {"sample_rate": 16000, "max_record_secs": 60}
 
 
+class TestMediaPlayersRoute:
+    """GET /media_players + HA alias (issue #73)."""
+
+    def test_returns_catalog(self, client, monkeypatch):
+        import intercom_server
+
+        catalog = [{"entity_id": "media_player.study", "name": "Study", "area": ""}]
+        monkeypatch.setattr(intercom_server.haclient, "media_player_catalog", lambda: catalog)
+        resp = client.get("/media_players")
+        assert resp.status_code == 200
+        assert resp.json == catalog
+
+    def test_ha_alias(self, client, monkeypatch):
+        import intercom_server
+
+        monkeypatch.setattr(intercom_server.haclient, "media_player_catalog", lambda: [])
+        resp = client.get("/api/home_intercom/media_players")
+        assert resp.status_code == 200
+        assert resp.json == []
+
+
 class TestRoomsStatus:
     def test_returns_500_without_token(self, client, monkeypatch):
         monkeypatch.setattr("intercom_server.HA_TOKEN", "")

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -7,12 +7,15 @@ from pathlib import Path
 
 import pytest
 from rooms import (
+    PLAY_MEDIA,
     RoomValidationError,
+    catalog_from_ha_states,
     load_rooms,
     patch_room,
     put_room,
     room_entity,
     save_rooms,
+    sort_media_player_catalog,
     validate_room_key,
 )
 
@@ -104,3 +107,44 @@ class TestLoadSave:
         save_rooms(str(store), {"new": {"name": "New", "entity": "media_player.b"}})
         rooms = load_rooms(str(store), str(seed))
         assert list(rooms) == ["new"]
+
+
+class TestMediaPlayerCatalog:
+    def test_filters_and_sorts(self) -> None:
+        states = [
+            {
+                "entity_id": "media_player.zebra",
+                "attributes": {"friendly_name": "Zebra", "supported_features": PLAY_MEDIA},
+            },
+            {
+                "entity_id": "light.lamp",
+                "attributes": {"friendly_name": "Lamp", "supported_features": PLAY_MEDIA},
+            },
+            {
+                "entity_id": "media_player.nope",
+                "attributes": {"friendly_name": "Nope", "supported_features": 0},
+            },
+            {
+                "entity_id": "media_player.alpha",
+                "attributes": {"friendly_name": "Alpha", "supported_features": PLAY_MEDIA},
+            },
+        ]
+        catalog = catalog_from_ha_states(states)
+        assert [e["entity_id"] for e in catalog] == [
+            "media_player.alpha",
+            "media_player.zebra",
+        ]
+        assert catalog[0]["area"] == ""
+
+    def test_area_sorts_before_unassigned(self) -> None:
+        catalog = sort_media_player_catalog(
+            [
+                {"entity_id": "media_player.z", "name": "Zebra", "area": ""},
+                {"entity_id": "media_player.a", "name": "Alpha", "area": "Kitchen"},
+            ]
+        )
+        assert [e["entity_id"] for e in catalog] == ["media_player.a", "media_player.z"]
+
+    def test_bad_payload(self) -> None:
+        assert catalog_from_ha_states(None) == []
+        assert catalog_from_ha_states("nope") == []


### PR DESCRIPTION
## Summary
- `GET /media_players` (and `/api/home_intercom/media_players`) returns speakers that support `play_media` as a JSON array of `entity_id`, friendly `name`, and `area` when known. Auth matches `GET /rooms` (public).
- HA uses the entity/area registry with the same filter as Options Flow. Config Flow still builds its dropdown from that catalog.
- Docker queries HA via `HAClient` `GET /api/states`. Area is empty because REST states do not include the area registry. Missing token or HA errors return `[]`.
- Closes #73.

## Test plan
- [x] Unit tests for HA catalog + area, REST catalog filter/sort, Flask route + HA alias, empty on missing token / HA error.
- [x] docker-smoke and HA smoke assert `GET /media_players` is a JSON array.
- [x] HA: `GET /api/home_intercom/media_players` lists play_media speakers with area names; players without `play_media` are omitted.
- [x] NAS Docker: `GET /media_players` lists the same speakers HA can play to; `area` is `""`.
- [x] PWA still has no picker UI (#74).


Made with [Cursor](https://cursor.com)