### PR TITLE
PWA: reorder rooms, pick card icons, and sync firmware

### DIFF
--- a/custom_components/home_intercom/__init__.py
+++ b/custom_components/home_intercom/__init__.py
@@ -44,6 +44,7 @@ from .const import (
 )
 from .device_store import DeviceStore
 from .firmware import refresh_cached_firmware
+from .rooms import combined_entry_rooms
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -77,10 +78,8 @@ UI_UNIQUE_ID = DOMAIN
 
 
 def _entry_room_map(entry: ConfigEntry) -> dict[str, dict[str, Any]]:
-    """Combined data + options rooms for one config entry (options win)."""
-    data_rooms = dict(entry.data.get(CONF_ROOMS, {}) or {})
-    options_rooms = dict(entry.options.get(CONF_ROOMS, {}) or {})
-    return {**data_rooms, **options_rooms}
+    """Combined data + options rooms for one config entry (options key order wins)."""
+    return combined_entry_rooms(entry)
 
 
 def merge_incoming_rooms(
@@ -199,9 +198,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _setup_device_store_listener(hass, entry)
         return True
 
-    data_rooms = entry.data.get(CONF_ROOMS, {})
-    options_rooms = entry.options.get(CONF_ROOMS, {})
-    room_map = {**data_rooms, **options_rooms}
+    room_map = combined_entry_rooms(entry)
 
     # Store per-entry rooms
     hass.data.setdefault(DOMAIN, {})

--- a/custom_components/home_intercom/api.py
+++ b/custom_components/home_intercom/api.py
@@ -15,6 +15,8 @@ Maps the Flask routes from intercom_server.py to HomeAssistantView:
   /devices/manage  → DevicesManageView (approve/deapprove/revoke/unrevoke/delete/ota/buttons)
   /firmware        → FirmwareView (GET cached .bin)
   /firmware.sig    → FirmwareSigView
+  /firmware/status → FirmwareStatusView (GET cached version)
+  /firmware/sync   → FirmwareSyncView (POST GitHub fetch, PWA token)
   /audio/<path>  → AudioView   (GET recorded WAV files)
   /home_intercom  → PanelView        (GET PWA frontend HTML, legacy path)
   /home-intercom  → PanelAliasView   (GET PWA frontend HTML, sidebar-friendly)
@@ -43,9 +45,11 @@ from .const import (
 from .firmware import (
     FirmwareError,
     ensure_latest_firmware,
+    firmware_cache_status,
     firmware_checksum_headers,
     load_cached_firmware,
     schedule_firmware_refresh,
+    sync_firmware_cache,
 )
 from .media_players import media_player_catalog
 from .player import play_announcement
@@ -881,6 +885,40 @@ async def _serve_static(request: web.Request, filename: str) -> web.Response:
     )
 
 
+class FirmwareStatusView(HomeAssistantView):
+    """GET /api/home_intercom/firmware/status — cached GitHub version for the PWA."""
+
+    url = "/api/home_intercom/firmware/status"
+    name = "api:home_intercom:firmware-status"
+    requires_auth = False  # public: version string only, same as /version
+
+    async def get(self, request: web.Request) -> web.Response:
+        hass = request.app["hass"]
+        return web.json_response(firmware_cache_status(_firmware_dir(hass)))
+
+
+class FirmwareSyncView(HomeAssistantView):
+    """POST /api/home_intercom/firmware/sync — fetch latest GitHub release into cache."""
+
+    url = "/api/home_intercom/firmware/sync"
+    name = "api:home_intercom:firmware-sync"
+    requires_auth = False  # auth via X-PWA-Token header
+
+    async def post(self, request: web.Request) -> web.Response:
+        denied = _verify_pwa_token(request, view="FirmwareSyncView")
+        if denied is not None:
+            return denied
+        hass = request.app["hass"]
+        try:
+            cached, updated = await hass.async_add_executor_job(
+                sync_firmware_cache, _firmware_dir(hass)
+            )
+        except FirmwareError as exc:
+            _LOGGER.warning("firmware sync failed: %s", exc)
+            return web.json_response({"ok": False, "error": "firmware unavailable"}, status=502)
+        return web.json_response({"ok": True, "version": cached.version, "updated": updated})
+
+
 class FirmwareView(HomeAssistantView):
     """GET /api/home_intercom/firmware — cached GitHub .bin for ESP32 OTA."""
 
@@ -955,6 +993,8 @@ def register_api_views(hass: HomeAssistant) -> None:
     hass.http.register_view(DevicesApproveView)
     hass.http.register_view(DevicesManageView)
     hass.http.register_view(DevicesView)
+    hass.http.register_view(FirmwareStatusView)
+    hass.http.register_view(FirmwareSyncView)
     hass.http.register_view(FirmwareView)
     hass.http.register_view(FirmwareSigView)
     hass.http.register_view(PanelView)

--- a/custom_components/home_intercom/api.py
+++ b/custom_components/home_intercom/api.py
@@ -8,6 +8,7 @@ Maps the Flask routes from intercom_server.py to HomeAssistantView:
   /version       → VersionView (GET version only)
   /rooms         → RoomsView       (GET room config)
   /rooms/{id}    → RoomsItemView   (PUT/PATCH/DELETE via PWA token)
+  /rooms/order   → RoomsOrderView  (PUT ordered id list via PWA token)
   /media_players  → MediaPlayersView (GET play_media speakers)
   /devices       → DevicesView        (GET registry)
   /devices/approve → DevicesApproveView
@@ -48,7 +49,14 @@ from .firmware import (
 )
 from .media_players import media_player_catalog
 from .player import play_announcement
-from .rooms import RoomValidationError, patch_room, put_room, validate_room_key
+from .rooms import (
+    RoomValidationError,
+    combined_entry_rooms,
+    patch_room,
+    put_room,
+    reorder_rooms,
+    validate_room_key,
+)
 from .shared import (
     buttons_from_manage_body,
     chime_public_url,
@@ -219,10 +227,8 @@ def _find_ui_entry(hass: HomeAssistant):
 
 
 def _entry_rooms(entry) -> dict:
-    """Combined data + options rooms for one config entry (options win)."""
-    data_rooms = dict(entry.data.get(CONF_ROOMS, {}) or {})
-    options_rooms = dict(entry.options.get(CONF_ROOMS, {}) or {})
-    return {**data_rooms, **options_rooms}
+    """Combined data + options rooms for one config entry (options key order wins)."""
+    return combined_entry_rooms(entry)
 
 
 def _persist_ui_rooms(hass: HomeAssistant, entry, rooms: dict) -> dict:
@@ -518,6 +524,33 @@ async def _rooms_write(request: web.Request, room_id: str, *, method: str) -> we
     ui_rooms[key] = room
     rooms = _persist_ui_rooms(hass, entry, ui_rooms)
     return web.json_response({"ok": True, "rooms": rooms})
+
+
+class RoomsOrderView(HomeAssistantView):
+    """PUT /api/home_intercom/rooms/order — persist settings-list order (#76)."""
+
+    url = "/api/home_intercom/rooms/order"
+    name = "api:home_intercom:rooms-order"
+    requires_auth = False  # auth via X-PWA-Token header
+
+    async def put(self, request: web.Request) -> web.Response:
+        denied = _verify_pwa_token(request, view="RoomsOrderView")
+        if denied is not None:
+            return denied
+        hass = request.app["hass"]
+        entry = _find_ui_entry(hass)
+        if entry is None:
+            return web.json_response({"ok": False, "error": "no writable config entry"}, status=409)
+        try:
+            body = await request.json()
+        except Exception:
+            body = None
+        try:
+            rooms = reorder_rooms(_entry_rooms(entry), (body or {}).get("order"))
+        except RoomValidationError as exc:
+            return web.json_response({"ok": False, "error": str(exc)}, status=400)
+        persisted = _persist_ui_rooms(hass, entry, rooms)
+        return web.json_response({"ok": True, "rooms": persisted})
 
 
 class MediaPlayersView(HomeAssistantView):
@@ -915,6 +948,7 @@ def register_api_views(hass: HomeAssistant) -> None:
     hass.http.register_view(VersionView)
     hass.http.register_view(ConfigView)
     hass.http.register_view(RoomsView)
+    hass.http.register_view(RoomsOrderView)
     hass.http.register_view(RoomsItemView)
     hass.http.register_view(MediaPlayersView)
     hass.http.register_view(DevicesHelloView)

--- a/custom_components/home_intercom/firmware.py
+++ b/custom_components/home_intercom/firmware.py
@@ -114,6 +114,28 @@ def load_cached_firmware(cache_dir: str) -> CachedFirmware | None:
     )
 
 
+def firmware_cache_status(cache_dir: str) -> dict[str, str]:
+    """JSON for GET ``/firmware/status`` — empty version when nothing is cached."""
+    cached = load_cached_firmware(cache_dir)
+    return {"version": cached.version if cached is not None else ""}
+
+
+def sync_firmware_cache(cache_dir: str) -> tuple[CachedFirmware, bool]:
+    """Fetch the latest GitHub release into the cache (PWA Sync).
+
+    Unlike ``ensure_latest_firmware``, GitHub failures are not swallowed by a
+    stale cache — the settings button should report that the sync failed.
+    Returns ``(cached, updated)`` where ``updated`` is True when the on-disk
+    image is new or changed.
+    """
+    previous = load_cached_firmware(cache_dir)
+    cached = _fetch_and_cache(cache_dir)
+    updated = (
+        previous is None or previous.version != cached.version or previous.sha256 != cached.sha256
+    )
+    return cached, updated
+
+
 def ensure_latest_firmware(cache_dir: str) -> CachedFirmware:
     """Download the latest GitHub ``.bin`` if the cache is missing or stale.
 

--- a/custom_components/home_intercom/intercom.html
+++ b/custom_components/home_intercom/intercom.html
@@ -171,6 +171,17 @@
       </div>
     </section>
     <p class="settings-msg" id="chime-msg" aria-live="polite"></p>
+    <section class="firmware-section" aria-labelledby="firmware-heading">
+      <div class="chime-heading">
+        <h3 id="firmware-heading" data-i18n="firmwareTitle">按钮固件</h3>
+        <p class="chime-desc" data-i18n="firmwareDesc">从 GitHub 缓存最新固件，供对讲按钮升级</p>
+      </div>
+      <div class="firmware-row">
+        <div class="firmware-status" id="firmware-status">—</div>
+        <button type="button" id="firmware-sync" class="settings-btn" data-i18n="firmwareSync">同步</button>
+      </div>
+      <p class="settings-msg" id="firmware-msg" aria-live="polite"></p>
+    </section>
   </div>
 </div>
 
@@ -1596,6 +1607,77 @@ async function resetChime() {
   }
 }
 
+function setFirmwareMsg(text) {
+  const el = document.getElementById('firmware-msg');
+  if (el) el.textContent = text || '';
+}
+
+let firmwareCachedVersion = '';
+
+function firmwareStatusLabel(version) {
+  if (!version) return I18N.t('firmwareNone');
+  return I18N.t('firmwareCached').replace('%s', version);
+}
+
+window.renderFirmwareStatus = function () {
+  const el = document.getElementById('firmware-status');
+  if (el) el.textContent = firmwareStatusLabel(firmwareCachedVersion);
+};
+
+async function refreshFirmwareStatus() {
+  try {
+    const resp = await fetch((window.API_BASE || '') + '/firmware/status', {
+      credentials: 'same-origin',
+      cache: 'no-store',
+      headers: authHeaders(),
+    });
+    if (!resp.ok) return;
+    const data = await resp.json().catch(() => ({}));
+    firmwareCachedVersion = (data && data.version) || '';
+    window.renderFirmwareStatus();
+  } catch (e) { /* ignore */ }
+}
+
+async function syncFirmwareCache() {
+  const btn = document.getElementById('firmware-sync');
+  setFirmwareMsg(I18N.t('firmwareSyncing'));
+  if (btn) btn.disabled = true;
+  try {
+    const resp = await fetch((window.API_BASE || '') + '/firmware/sync', {
+      method: 'POST',
+      credentials: 'same-origin',
+      cache: 'no-store',
+      headers: authHeaders(),
+    });
+    if (resp.status === 401 && !sessionStorage.getItem(RELOAD_ONCE_KEY)) {
+      sessionStorage.setItem(RELOAD_ONCE_KEY, '1');
+      location.reload();
+      return;
+    }
+    const data = await resp.json().catch(() => ({}));
+    if (!resp.ok || !data.ok) {
+      setFirmwareMsg(I18N.t('firmwareSyncFail'));
+      return;
+    }
+    firmwareCachedVersion = data.version || '';
+    window.renderFirmwareStatus();
+    setFirmwareMsg(I18N.t(data.updated ? 'firmwareUpdated' : 'firmwareLatest').replace('%s', firmwareCachedVersion));
+    if (typeof loadDevices === 'function') loadDevices();
+  } catch (e) {
+    setFirmwareMsg(I18N.t('firmwareSyncFail'));
+    console.error('syncFirmwareCache:', e);
+  } finally {
+    if (btn) btn.disabled = false;
+  }
+}
+
+function initFirmwareSettings() {
+  const btn = document.getElementById('firmware-sync');
+  if (!btn || btn.dataset.bound) return;
+  btn.dataset.bound = '1';
+  btn.addEventListener('click', syncFirmwareCache);
+}
+
 function openSettingsPanel() {
   const overlay = document.getElementById('settings-overlay');
   const toggle = document.getElementById('settings-toggle');
@@ -1606,7 +1688,9 @@ function openSettingsPanel() {
   toggle.setAttribute('aria-expanded', 'true');
   setChimeMsg('');
   setRoomsMsg('');
+  setFirmwareMsg('');
   refreshChimeStatus();
+  refreshFirmwareStatus();
   loadMediaPlayers().then(() => {
     if (typeof window.renderRoomsSettings === 'function') window.renderRoomsSettings();
   });
@@ -1701,6 +1785,7 @@ document.addEventListener('visibilitychange', () => {
 initDevicesToggle();
 initRoomsSettings();
 initChimeSettings();
+initFirmwareSettings();
 
 // Show version number
 fetch((window.API_BASE || '') + '/version', { credentials: 'same-origin' }).then(r => r.json()).then(d => {

--- a/custom_components/home_intercom/intercom.html
+++ b/custom_components/home_intercom/intercom.html
@@ -525,6 +525,7 @@ function el(tag, className, text) {
 function deviceActionButton(label, extraClass, onClick, disabled) {
   const btn = el('button', 'device-action' + (extraClass ? ' ' + extraClass : ''), label);
   btn.type = 'button';
+  btn.draggable = false;
   if (disabled) {
     btn.disabled = true;
   }
@@ -955,6 +956,99 @@ function roomsFormOpen() {
   return !!(form && !form.hidden);
 }
 
+// HTML5 drag&drop sortable list (https://stackoverflow.com/q/10588607)
+let _el;
+
+function isBefore(el1, el2) {
+  if (el2.parentNode === el1.parentNode) {
+    for (let cur = el1.previousSibling; cur && cur.nodeType !== 9; cur = cur.previousSibling) {
+      if (cur === el2) return true;
+    }
+  }
+  return false;
+}
+
+function roomRowFromEvent(e) {
+  let node = e.target;
+  if (node && node.nodeType !== 1) node = node.parentNode;
+  return node && node.closest ? node.closest('#rooms-list .rooms-row') : null;
+}
+
+function dragStart(e) {
+  if (e.target.closest && e.target.closest('button, select, input')) {
+    e.preventDefault();
+    return;
+  }
+  e.dataTransfer.effectAllowed = 'move';
+  e.dataTransfer.setData('text/plain', null);
+  _el = e.currentTarget;
+  _el.classList.add('dragging');
+}
+
+function dragOver(e) {
+  e.preventDefault();
+  const target = roomRowFromEvent(e);
+  if (!_el || !target || target === _el) return;
+  if (isBefore(_el, target)) target.parentNode.insertBefore(_el, target);
+  else target.parentNode.insertBefore(_el, target.nextSibling);
+}
+
+function dragEnd() {
+  if (_el) _el.classList.remove('dragging');
+  _el = null;
+  persistRoomOrder();
+}
+
+function bindRoomReorder(row) {
+  row.draggable = true;
+  row.setAttribute('aria-label', I18N.t('roomsDrag'));
+  row.addEventListener('dragstart', dragStart);
+  row.addEventListener('dragover', dragOver);
+  row.addEventListener('dragend', dragEnd);
+}
+
+function roomOrderRows() {
+  return [...document.querySelectorAll('#rooms-list .rooms-row')];
+}
+
+async function persistRoomOrder() {
+  const order = roomOrderRows().map((r) => r.dataset.roomId).filter(Boolean);
+  const current = Object.keys(catalogRooms());
+  if (order.length !== current.length || order.every((key, i) => key === current[i])) return;
+  try {
+    const resp = await fetch((window.API_BASE || '') + '/rooms/order', {
+      method: 'PUT',
+      credentials: 'same-origin',
+      cache: 'no-store',
+      headers: authHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify({ order }),
+    });
+    const data = await resp.json().catch(() => ({}));
+    if (!resp.ok || !data.ok) throw new Error(data.error || 'order');
+    const rooms = data.rooms && typeof data.rooms === 'object' ? data.rooms : {};
+    const all = window._ROOM_DATA && window._ROOM_DATA.all;
+    window._ROOM_DATA = all ? { all } : {};
+    ROOM_NAMES = { all: I18N.t('broadcastAll') };
+    for (const [key, room] of Object.entries(rooms)) {
+      window._ROOM_DATA[key] = room;
+      ROOM_NAMES[key] = room.name;
+    }
+    const cards = [...GRID.querySelectorAll('.room-card:not(.broadcast-card)')];
+    const byId = Object.fromEntries(cards.map((c) => [c.id.replace(/^card-/, ''), c]));
+    const keys = Object.keys(rooms);
+    if (keys.length === cards.length && keys.every((k) => byId[k])) {
+      for (const key of keys) GRID.appendChild(byId[key]);
+    } else {
+      rebuildRoomGrid(rooms);
+    }
+    if (typeof window.renderDevices === 'function' && window._DEVICES) window.renderDevices();
+  } catch (err) {
+    console.error('persistRoomOrder:', err);
+    setRoomsMsg(I18N.t('roomsSaveFail'));
+    await loadRooms();
+  }
+}
+
 window.renderRoomsSettings = function () {
   const list = document.getElementById('rooms-list');
   const empty = document.getElementById('rooms-empty');
@@ -980,6 +1074,7 @@ window.renderRoomsSettings = function () {
     const entityId = roomEntity(room);
     const player = playerById(entityId);
     const row = el('div', 'rooms-row');
+    row.dataset.roomId = key;
     const info = el('div', 'rooms-row-info');
     info.appendChild(el('div', 'rooms-row-name', room.name || key));
     const entityClass = player || !entityId ? 'rooms-row-entity' : 'rooms-row-entity rooms-row-entity-missing';
@@ -989,6 +1084,7 @@ window.renderRoomsSettings = function () {
     actions.appendChild(deviceActionButton(I18N.t('roomsDelete'), 'danger', () => deleteRoom(key)));
     row.appendChild(info);
     row.appendChild(actions);
+    if (keys.length > 1) bindRoomReorder(row);
     list.appendChild(row);
   }
 };

--- a/custom_components/home_intercom/intercom.html
+++ b/custom_components/home_intercom/intercom.html
@@ -115,6 +115,11 @@
           <span data-i18n="roomsName">名称</span>
           <input type="text" id="room-name" maxlength="64" required autocomplete="off">
         </label>
+        <div class="rooms-field">
+          <span data-i18n="roomsIcon">图标</span>
+          <input type="hidden" id="room-icon" value="">
+          <div class="rooms-icon-picker" id="room-icon-picker" role="radiogroup" aria-label="图标"></div>
+        </div>
         <label class="rooms-field">
           <span data-i18n="roomsPlayer">扬声器</span>
           <select id="room-player" required></select>
@@ -220,7 +225,9 @@ let currentTarget = '';
 let currentCard = null;
 let ROOM_NAMES = {};
 
-// Room icon mapping (extensible, falls back to 📢)
+// Room icons (issue #85). Presets must match rooms.py ROOM_ICONS.
+const ROOM_ICON_DEFAULT = '🔊';
+const ROOM_ICON_PRESETS = ['🔊','🛋️','🛏️','📚','🎬','📺','🍽️','🚿','🚪','🌳','🎵','💻'];
 const ROOM_ICONS = {
   all:     '📢',
   living:  '🛋️',
@@ -228,11 +235,14 @@ const ROOM_ICONS = {
   study:   '📚',
   cinema:  '🎬',
 };
-function roomIcon(target) {
-  return ROOM_ICONS[target] || '🔊';
+function roomIcon(target, room) {
+  if (target === 'all') return ROOM_ICONS.all;
+  const stored = room && typeof room.icon === 'string' ? room.icon.trim() : '';
+  if (ROOM_ICON_PRESETS.includes(stored)) return stored;
+  return ROOM_ICONS[target] || ROOM_ICON_DEFAULT;
 }
 
-function makeCard(target, name, isBroadcast) {
+function makeCard(target, name, isBroadcast, room) {
   const card = document.createElement('div');
   card.className = 'room-card' + (isBroadcast ? ' broadcast-card' : '');
   card.id = 'card-' + target;
@@ -269,7 +279,7 @@ function makeCard(target, name, isBroadcast) {
             <span class="device-name">…</span>
           </div>
         </div>
-        <span class="room-icon">${roomIcon(target)}</span>
+        <span class="room-icon">${roomIcon(target, room)}</span>
       </div>
       ${pttHtml}
       <div class="status">${I18N.t('statusReady')}</div>`;
@@ -387,7 +397,7 @@ function rebuildRoomGrid(rooms) {
     for (const [key, room] of Object.entries(rooms)) {
       window._ROOM_DATA[key] = room;
       ROOM_NAMES[key] = room.name;
-      GRID.appendChild(makeCard(key, room.name, false));
+      GRID.appendChild(makeCard(key, room.name, false, room));
     }
   }
   if (typeof window.renderRoomsSettings === 'function') window.renderRoomsSettings();
@@ -1076,7 +1086,12 @@ window.renderRoomsSettings = function () {
     const row = el('div', 'rooms-row');
     row.dataset.roomId = key;
     const info = el('div', 'rooms-row-info');
-    info.appendChild(el('div', 'rooms-row-name', room.name || key));
+    const nameWrap = el('div', 'rooms-row-name');
+    const glyph = el('span', 'rooms-row-icon', roomIcon(key, room));
+    glyph.setAttribute('aria-hidden', 'true');
+    nameWrap.appendChild(glyph);
+    nameWrap.appendChild(el('span', 'rooms-row-name-text', room.name || key));
+    info.appendChild(nameWrap);
     const entityClass = player || !entityId ? 'rooms-row-entity' : 'rooms-row-entity rooms-row-entity-missing';
     info.appendChild(el('div', entityClass, player ? playerLabel(player) : (entityId ? playerMissingLabel(entityId) : '')));
     const actions = el('div', 'rooms-row-actions');
@@ -1088,6 +1103,36 @@ window.renderRoomsSettings = function () {
     list.appendChild(row);
   }
 };
+
+function fillIconPicker(selected) {
+  const picker = document.getElementById('room-icon-picker');
+  const input = document.getElementById('room-icon');
+  if (!picker || !input) return;
+  const icon = ROOM_ICON_PRESETS.includes(selected) ? selected : ROOM_ICON_DEFAULT;
+  input.value = icon;
+  picker.setAttribute('aria-label', I18N.t('roomsIcon'));
+  picker.replaceChildren();
+  for (const glyph of ROOM_ICON_PRESETS) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'rooms-icon-opt' + (glyph === icon ? ' selected' : '');
+    btn.dataset.icon = glyph;
+    btn.textContent = glyph;
+    btn.draggable = false;
+    btn.setAttribute('role', 'radio');
+    btn.setAttribute('aria-checked', glyph === icon ? 'true' : 'false');
+    btn.setAttribute('aria-label', glyph);
+    btn.addEventListener('click', () => {
+      input.value = glyph;
+      picker.querySelectorAll('.rooms-icon-opt').forEach((el) => {
+        const on = el.dataset.icon === glyph;
+        el.classList.toggle('selected', on);
+        el.setAttribute('aria-checked', on ? 'true' : 'false');
+      });
+    });
+    picker.appendChild(btn);
+  }
+}
 
 function resetRoomFormState() {
   const form = document.getElementById('rooms-form');
@@ -1105,6 +1150,7 @@ function resetRoomFormState() {
   if (volumeEl) volumeEl.value = '';
   if (pauseEl) pauseEl.value = '';
   if (playerEl) playerEl.classList.remove('rooms-player-missing');
+  fillIconPicker(ROOM_ICON_DEFAULT);
 }
 
 function closeRoomForm() {
@@ -1130,6 +1176,7 @@ function openRoomForm(roomId) {
   volumeEl.value = room && room.announce_volume ? String(room.announce_volume) : '';
   pauseEl.value = room && room.pause_buffer ? String(room.pause_buffer) : '';
   fillPlayerSelect(room ? roomEntity(room) : '');
+  fillIconPicker(roomId ? roomIcon(roomId, room) : ROOM_ICON_DEFAULT);
   if (!roomId) {
     const select = document.getElementById('room-player');
     const first = select && !select.disabled ? select.value : '';
@@ -1166,6 +1213,7 @@ async function saveRoom(e) {
   const body = {
     name,
     entity_id: entityId,
+    icon: document.getElementById('room-icon').value.trim() || ROOM_ICON_DEFAULT,
     announce_volume: optionalNumber(document.getElementById('room-volume'), { integer: true }),
     pause_buffer: optionalNumber(document.getElementById('room-pause')),
   };

--- a/custom_components/home_intercom/intercom.html
+++ b/custom_components/home_intercom/intercom.html
@@ -977,55 +977,124 @@ function roomsFormOpen() {
   return !!(form && !form.hidden);
 }
 
-// HTML5 drag&drop sortable list (https://stackoverflow.com/q/10588607)
-let _el;
+// Pointer sortable. HTML5 DnD does not fire on iOS and is incomplete on Android.
+const REORDER_HOLD_MS = 200;
+const REORDER_MOVE_PX = 8;
+let _reorder = null;
 
-function isBefore(el1, el2) {
-  if (el2.parentNode === el1.parentNode) {
-    for (let cur = el1.previousSibling; cur && cur.nodeType !== 9; cur = cur.previousSibling) {
-      if (cur === el2) return true;
-    }
+function reorderIgnoreTarget(target) {
+  return !!(target && target.closest && target.closest('button, select, input, a'));
+}
+
+function clearReorderTimer() {
+  if (_reorder && _reorder.timer) {
+    clearTimeout(_reorder.timer);
+    _reorder.timer = 0;
   }
-  return false;
 }
 
-function roomRowFromEvent(e) {
-  let node = e.target;
-  if (node && node.nodeType !== 1) node = node.parentNode;
-  return node && node.closest ? node.closest('#rooms-list .rooms-row') : null;
+function unbindReorderWindow() {
+  window.removeEventListener('pointermove', onReorderPointerMove, true);
+  window.removeEventListener('pointerup', onReorderPointerUp, true);
+  window.removeEventListener('pointercancel', onReorderPointerUp, true);
+  window.removeEventListener('touchmove', onReorderTouchMove, true);
 }
 
-function dragStart(e) {
-  if (e.target.closest && e.target.closest('button, select, input')) {
-    e.preventDefault();
-    return;
-  }
-  e.dataTransfer.effectAllowed = 'move';
-  e.dataTransfer.setData('text/plain', null);
-  _el = e.currentTarget;
-  _el.classList.add('dragging');
-}
-
-function dragOver(e) {
-  e.preventDefault();
-  const target = roomRowFromEvent(e);
-  if (!_el || !target || target === _el) return;
-  if (isBefore(_el, target)) target.parentNode.insertBefore(_el, target);
-  else target.parentNode.insertBefore(_el, target.nextSibling);
-}
-
-function dragEnd() {
-  if (_el) _el.classList.remove('dragging');
-  _el = null;
-  persistRoomOrder();
+function bindReorderWindow() {
+  window.addEventListener('pointermove', onReorderPointerMove, true);
+  window.addEventListener('pointerup', onReorderPointerUp, true);
+  window.addEventListener('pointercancel', onReorderPointerUp, true);
+  window.addEventListener('touchmove', onReorderTouchMove, { capture: true, passive: false });
 }
 
 function bindRoomReorder(row) {
-  row.draggable = true;
+  row.classList.add('rooms-row-sortable');
   row.setAttribute('aria-label', I18N.t('roomsDrag'));
-  row.addEventListener('dragstart', dragStart);
-  row.addEventListener('dragover', dragOver);
-  row.addEventListener('dragend', dragEnd);
+  row.addEventListener('pointerdown', onReorderPointerDown);
+}
+
+function onReorderPointerDown(e) {
+  if (e.pointerType === 'mouse' && e.button !== 0) return;
+  if (reorderIgnoreTarget(e.target)) return;
+  if (_reorder) endReorder(false);
+  _reorder = {
+    row: e.currentTarget,
+    pointerId: e.pointerId,
+    pointerType: e.pointerType,
+    startX: e.clientX,
+    startY: e.clientY,
+    dragging: false,
+    timer: 0,
+  };
+  bindReorderWindow();
+  if (e.pointerType !== 'mouse') {
+    _reorder.timer = setTimeout(beginReorder, REORDER_HOLD_MS);
+  }
+}
+
+function onReorderTouchMove(e) {
+  if (_reorder && _reorder.dragging) e.preventDefault();
+}
+
+function onReorderPointerMove(e) {
+  if (!_reorder || e.pointerId !== _reorder.pointerId) return;
+  const dist = Math.hypot(e.clientX - _reorder.startX, e.clientY - _reorder.startY);
+  if (_reorder.dragging) {
+    e.preventDefault();
+    reorderByClientY(e.clientY);
+    return;
+  }
+  if (dist < REORDER_MOVE_PX) return;
+  if (_reorder.pointerType === 'mouse') {
+    beginReorder();
+    reorderByClientY(e.clientY);
+    return;
+  }
+  endReorder(false);
+}
+
+function onReorderPointerUp(e) {
+  if (!_reorder || e.pointerId !== _reorder.pointerId) return;
+  endReorder(_reorder.dragging);
+}
+
+function beginReorder() {
+  if (!_reorder || _reorder.dragging) return;
+  clearReorderTimer();
+  _reorder.dragging = true;
+  _reorder.row.classList.add('dragging');
+  try { _reorder.row.setPointerCapture(_reorder.pointerId); } catch (err) { /* older WebKit */ }
+  if (_reorder.pointerType !== 'mouse' && navigator.vibrate) {
+    try { navigator.vibrate(12); } catch (err) { /* ignore */ }
+  }
+}
+
+function reorderByClientY(clientY) {
+  const row = _reorder && _reorder.row;
+  if (!row || !row.parentNode) return;
+  const rows = roomOrderRows();
+  let next = null;
+  for (const other of rows) {
+    if (other === row) continue;
+    const box = other.getBoundingClientRect();
+    if (clientY < box.top + box.height / 2) {
+      next = other;
+      break;
+    }
+  }
+  if (next) row.parentNode.insertBefore(row, next);
+  else row.parentNode.appendChild(row);
+}
+
+function endReorder(persist) {
+  if (!_reorder) return;
+  clearReorderTimer();
+  unbindReorderWindow();
+  const row = _reorder.row;
+  try { row.releasePointerCapture(_reorder.pointerId); } catch (err) { /* not captured */ }
+  row.classList.remove('dragging');
+  _reorder = null;
+  if (persist) persistRoomOrder();
 }
 
 function roomOrderRows() {

--- a/custom_components/home_intercom/rooms.py
+++ b/custom_components/home_intercom/rooms.py
@@ -27,6 +27,24 @@ ENTITY_RE = re.compile(r"^media_player\.[a-z0-9_]+$")
 RESERVED_ROOM_KEYS = frozenset({"all", "status", "order"})
 MAX_ROOM_NAME_LEN = 64
 MAX_PAUSE_BUFFER = 10.0
+ICON_KEY = "icon"
+# Keep in sync with ROOM_ICON_PRESETS in intercom.html (issue #85).
+ROOM_ICONS = frozenset(
+    {
+        "🔊",
+        "🛋️",
+        "🛏️",
+        "📚",
+        "🎬",
+        "📺",
+        "🍽️",
+        "🚿",
+        "🚪",
+        "🌳",
+        "🎵",
+        "💻",
+    }
+)
 # MediaPlayerEntityFeature.PLAY_MEDIA — same bit Options Flow uses.
 PLAY_MEDIA = 1 << 9
 
@@ -134,6 +152,20 @@ def _parse_pause_buffer(value: Any) -> float | None:
     return buf
 
 
+def _parse_icon(value: Any) -> str | None:
+    """Return an allowlisted emoji, or None to omit/clear. Empty and null clear."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise RoomValidationError("invalid icon")
+    icon = value.strip()
+    if icon == "":
+        return None
+    if icon not in ROOM_ICONS:
+        raise RoomValidationError("invalid icon")
+    return icon
+
+
 def _apply_optional(room: dict[str, Any], body: dict[str, Any], *, replace: bool) -> None:
     if replace or CONF_ANNOUNCE_VOLUME in body:
         volume = _parse_announce_volume(body.get(CONF_ANNOUNCE_VOLUME))
@@ -147,6 +179,12 @@ def _apply_optional(room: dict[str, Any], body: dict[str, Any], *, replace: bool
             room.pop(CONF_PAUSE_BUFFER, None)
         else:
             room[CONF_PAUSE_BUFFER] = buf
+    if replace or ICON_KEY in body:
+        icon = _parse_icon(body.get(ICON_KEY))
+        if icon is None:
+            room.pop(ICON_KEY, None)
+        else:
+            room[ICON_KEY] = icon
 
 
 def put_room(body: Any, *, entity_key: EntityKey) -> dict[str, Any]:
@@ -166,7 +204,7 @@ def patch_room(existing: dict[str, Any], body: Any, *, entity_key: EntityKey) ->
     """Merge PATCH fields into an existing room."""
     if not isinstance(body, dict):
         raise RoomValidationError("invalid body")
-    known = {"name", "entity", "entity_id", CONF_ANNOUNCE_VOLUME, CONF_PAUSE_BUFFER}
+    known = {"name", "entity", "entity_id", CONF_ANNOUNCE_VOLUME, CONF_PAUSE_BUFFER, ICON_KEY}
     if not any(key in body for key in known):
         raise RoomValidationError("empty patch")
     room = dict(existing)

--- a/custom_components/home_intercom/rooms.py
+++ b/custom_components/home_intercom/rooms.py
@@ -16,15 +16,15 @@ import re
 from typing import Any, Literal
 
 try:
-    from .const import CONF_ANNOUNCE_VOLUME, CONF_PAUSE_BUFFER
+    from .const import CONF_ANNOUNCE_VOLUME, CONF_PAUSE_BUFFER, CONF_ROOMS
 except ImportError:
-    from const import CONF_ANNOUNCE_VOLUME, CONF_PAUSE_BUFFER
+    from const import CONF_ANNOUNCE_VOLUME, CONF_PAUSE_BUFFER, CONF_ROOMS
 
 _LOGGER = logging.getLogger(__name__)
 
 ROOM_KEY_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$")
 ENTITY_RE = re.compile(r"^media_player\.[a-z0-9_]+$")
-RESERVED_ROOM_KEYS = frozenset({"all", "status"})
+RESERVED_ROOM_KEYS = frozenset({"all", "status", "order"})
 MAX_ROOM_NAME_LEN = 64
 MAX_PAUSE_BUFFER = 10.0
 # MediaPlayerEntityFeature.PLAY_MEDIA — same bit Options Flow uses.
@@ -35,6 +35,41 @@ EntityKey = Literal["entity", "entity_id"]
 
 class RoomValidationError(ValueError):
     """Invalid room key or body. ``str(exc)`` is safe to return to the client."""
+
+
+def combined_entry_rooms(entry: Any) -> dict[str, Any]:
+    """Rooms for one HA config entry. Options key order wins when set (issue #76)."""
+    data = getattr(entry, "data", None) or {}
+    options = getattr(entry, "options", None) or {}
+    data_rooms = dict(data.get(CONF_ROOMS) or {})
+    if CONF_ROOMS in options:
+        merged = dict(options.get(CONF_ROOMS) or {})
+        for key, room in data_rooms.items():
+            if key not in merged and isinstance(room, dict):
+                merged[key] = room
+        return merged
+    return data_rooms
+
+
+def reorder_rooms(rooms: dict[str, Any], order: Any) -> dict[str, Any]:
+    """Return ``rooms`` in ``order``. ``order`` must be a permutation of the keys."""
+    if not isinstance(order, list):
+        raise RoomValidationError("invalid order")
+    keys: list[str] = []
+    seen: set[str] = set()
+    for item in order:
+        if not isinstance(item, str):
+            raise RoomValidationError("invalid order")
+        key = validate_room_key(item)
+        if key not in rooms:
+            raise RoomValidationError("unknown room")
+        if key in seen:
+            raise RoomValidationError("invalid order")
+        seen.add(key)
+        keys.append(key)
+    if seen != set(rooms):
+        raise RoomValidationError("invalid order")
+    return {key: rooms[key] for key in keys}
 
 
 def validate_room_key(room_id: str) -> str:

--- a/custom_components/home_intercom/static/i18n.js
+++ b/custom_components/home_intercom/static/i18n.js
@@ -93,6 +93,7 @@ const I18N = (() => {
       roomsPlayerRemoved: "%s（已移除）",
       roomsErrorNoEntry: "没有可写入的配置项",
       roomsErrorUnknown: "找不到这个房间",
+      roomsDrag: "拖动排序",
     },
     en: {
       appTitle: "Home Intercom",
@@ -176,6 +177,7 @@ const I18N = (() => {
       roomsPlayerRemoved: "%s (removed)",
       roomsErrorNoEntry: "No writable config entry",
       roomsErrorUnknown: "Unknown room",
+      roomsDrag: "Drag to reorder",
     },
   };
 
@@ -309,6 +311,9 @@ const I18N = (() => {
     const settingsClose = document.getElementById("settings-close");
     if (settingsToggle) settingsToggle.setAttribute("aria-label", t("settingsTitle"));
     if (settingsClose) settingsClose.setAttribute("aria-label", t("settingsClose"));
+    document.querySelectorAll("#rooms-list .rooms-row[draggable='true']").forEach((el) => {
+      el.setAttribute("aria-label", t("roomsDrag"));
+    });
     if (typeof THEME !== "undefined" && typeof THEME.updateDropdown === "function") THEME.updateDropdown();
   }
 

--- a/custom_components/home_intercom/static/i18n.js
+++ b/custom_components/home_intercom/static/i18n.js
@@ -95,6 +95,15 @@ const I18N = (() => {
       roomsErrorNoEntry: "没有可写入的配置项",
       roomsErrorUnknown: "找不到这个房间",
       roomsDrag: "拖动排序",
+      firmwareTitle: "按钮固件",
+      firmwareDesc: "从 GitHub 缓存最新固件，供对讲按钮升级",
+      firmwareSync: "同步",
+      firmwareNone: "尚未缓存",
+      firmwareCached: "已缓存 %s",
+      firmwareUpdated: "已缓存新版本 %s",
+      firmwareLatest: "已是最新 %s",
+      firmwareSyncFail: "同步失败",
+      firmwareSyncing: "正在同步…",
     },
     en: {
       appTitle: "Home Intercom",
@@ -180,6 +189,15 @@ const I18N = (() => {
       roomsErrorNoEntry: "No writable config entry",
       roomsErrorUnknown: "Unknown room",
       roomsDrag: "Drag to reorder",
+      firmwareTitle: "Button firmware",
+      firmwareDesc: "Cache the latest GitHub firmware for button updates",
+      firmwareSync: "Sync",
+      firmwareNone: "Not cached",
+      firmwareCached: "Cached %s",
+      firmwareUpdated: "Cached new version %s",
+      firmwareLatest: "Already latest %s",
+      firmwareSyncFail: "Sync failed",
+      firmwareSyncing: "Syncing…",
     },
   };
 
@@ -292,6 +310,7 @@ const I18N = (() => {
     // Re-render the device list with the new language (room names change)
     if (typeof window.renderDevices === "function") window.renderDevices();
     if (typeof window.renderRoomsSettings === "function") window.renderRoomsSettings();
+    if (typeof window.renderFirmwareStatus === "function") window.renderFirmwareStatus();
 
     document.title = t("appTitle");
 

--- a/custom_components/home_intercom/static/i18n.js
+++ b/custom_components/home_intercom/static/i18n.js
@@ -94,7 +94,7 @@ const I18N = (() => {
       roomsPlayerRemoved: "%s（已移除）",
       roomsErrorNoEntry: "没有可写入的配置项",
       roomsErrorUnknown: "找不到这个房间",
-      roomsDrag: "拖动排序",
+      roomsDrag: "按住拖动排序",
       firmwareTitle: "按钮固件",
       firmwareDesc: "从 GitHub 缓存最新固件，供对讲按钮升级",
       firmwareSync: "同步",
@@ -188,7 +188,7 @@ const I18N = (() => {
       roomsPlayerRemoved: "%s (removed)",
       roomsErrorNoEntry: "No writable config entry",
       roomsErrorUnknown: "Unknown room",
-      roomsDrag: "Drag to reorder",
+      roomsDrag: "Hold and drag to reorder",
       firmwareTitle: "Button firmware",
       firmwareDesc: "Cache the latest GitHub firmware for button updates",
       firmwareSync: "Sync",
@@ -335,7 +335,7 @@ const I18N = (() => {
     const settingsClose = document.getElementById("settings-close");
     if (settingsToggle) settingsToggle.setAttribute("aria-label", t("settingsTitle"));
     if (settingsClose) settingsClose.setAttribute("aria-label", t("settingsClose"));
-    document.querySelectorAll("#rooms-list .rooms-row[draggable='true']").forEach((el) => {
+    document.querySelectorAll("#rooms-list .rooms-row-sortable").forEach((el) => {
       el.setAttribute("aria-label", t("roomsDrag"));
     });
     if (typeof THEME !== "undefined" && typeof THEME.updateDropdown === "function") THEME.updateDropdown();

--- a/custom_components/home_intercom/static/i18n.js
+++ b/custom_components/home_intercom/static/i18n.js
@@ -76,6 +76,7 @@ const I18N = (() => {
       roomsEmpty: "还没有房间。添加一个扬声器开始使用。",
       roomsAdd: "添加房间",
       roomsName: "名称",
+      roomsIcon: "图标",
       roomsPlayer: "扬声器",
       roomsVolume: "播报音量",
       roomsPause: "暂停缓冲（秒）",
@@ -160,6 +161,7 @@ const I18N = (() => {
       roomsEmpty: "No rooms yet. Add a speaker to get started.",
       roomsAdd: "Add room",
       roomsName: "Name",
+      roomsIcon: "Icon",
       roomsPlayer: "Speaker",
       roomsVolume: "Announce volume",
       roomsPause: "Pause buffer (s)",
@@ -283,6 +285,9 @@ const I18N = (() => {
     document.querySelectorAll("[data-i18n]").forEach((el) => {
       el.textContent = t(el.getAttribute("data-i18n"));
     });
+
+    const iconPicker = document.getElementById("room-icon-picker");
+    if (iconPicker) iconPicker.setAttribute("aria-label", t("roomsIcon"));
 
     // Re-render the device list with the new language (room names change)
     if (typeof window.renderDevices === "function") window.renderDevices();

--- a/custom_components/home_intercom/static/intercom.css
+++ b/custom_components/home_intercom/static/intercom.css
@@ -690,6 +690,23 @@ html[data-theme-pref="dark"] #theme-toggle-icon {
   background: var(--danger-btn-bg-disabled);
 }
 
+.firmware-section {
+  margin-top: 18px;
+}
+
+.firmware-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.firmware-status {
+  min-width: 0;
+  font-size: 0.78rem;
+  color: var(--text-heading);
+}
+
 .chime-upload-label {
   display: inline-flex;
   align-items: center;

--- a/custom_components/home_intercom/static/intercom.css
+++ b/custom_components/home_intercom/static/intercom.css
@@ -335,10 +335,24 @@ html[data-theme-pref="dark"] #theme-toggle-icon {
 }
 
 .rooms-row-name {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
   font-size: 0.78rem;
   line-height: 1.2;
   font-weight: 500;
   color: var(--text-heading);
+}
+
+.rooms-row-icon {
+  flex-shrink: 0;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.rooms-row-name-text {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -390,6 +404,38 @@ html[data-theme-pref="dark"] #theme-toggle-icon {
   user-select: text;
   /* stylelint-disable-next-line property-no-vendor-prefix */
   -webkit-user-select: text;
+}
+
+.rooms-icon-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.rooms-icon-opt {
+  appearance: none;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.15rem;
+  line-height: 1;
+  background: var(--surface-2);
+  border: 1px solid var(--border-2);
+  border-radius: 10px;
+  color: var(--fg);
+  cursor: pointer;
+}
+
+.rooms-icon-opt:hover {
+  background: var(--surface-hover);
+}
+
+.rooms-icon-opt.selected {
+  border-color: var(--accent);
+  background: var(--surface-3);
 }
 
 .rooms-form-actions {

--- a/custom_components/home_intercom/static/intercom.css
+++ b/custom_components/home_intercom/static/intercom.css
@@ -318,6 +318,15 @@ html[data-theme-pref="dark"] #theme-toggle-icon {
   border: 1px solid var(--border);
   border-radius: 12px;
   padding: 10px 12px;
+  user-select: none;
+}
+
+.rooms-row[draggable="true"] {
+  cursor: grab;
+}
+
+.rooms-row.dragging {
+  opacity: 0.65;
 }
 
 .rooms-row-info {

--- a/custom_components/home_intercom/static/intercom.css
+++ b/custom_components/home_intercom/static/intercom.css
@@ -321,12 +321,17 @@ html[data-theme-pref="dark"] #theme-toggle-icon {
   user-select: none;
 }
 
-.rooms-row[draggable="true"] {
+.rooms-row-sortable {
   cursor: grab;
+  touch-action: pan-y;
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -webkit-touch-callout: none;
 }
 
 .rooms-row.dragging {
+  cursor: grabbing;
   opacity: 0.65;
+  touch-action: none;
 }
 
 .rooms-row-info {

--- a/src/intercom_server.py
+++ b/src/intercom_server.py
@@ -26,6 +26,7 @@ from rooms import (
     load_rooms,
     patch_room,
     put_room,
+    reorder_rooms,
     room_entity,
     save_rooms,
     validate_room_key,
@@ -55,6 +56,7 @@ from device_store import DeviceStore
 from ha_client import DEFAULT_STATE_TIMEOUT, HAClient
 
 app = Flask(__name__)
+app.json.sort_keys = False  # GET /rooms must keep PWA list order (#76)
 
 HA_URL = os.environ.get("HA_URL", "")
 HA_TOKEN = os.environ.get("HA_TOKEN", "")
@@ -127,6 +129,26 @@ def rooms():
 def _persist_room_map():
     """Write ROOM_MAP to the Docker store. Raises OSError if the path is not writable."""
     save_rooms(ROOMS_STORE, ROOM_MAP)
+
+
+@app.route("/rooms/order", methods=["PUT"])
+def rooms_order():
+    """Replace catalog key order. LAN trust, same as /chime POST (#76)."""
+    body = request.get_json(silent=True)
+    try:
+        reordered = reorder_rooms(ROOM_MAP, (body or {}).get("order"))
+    except RoomValidationError as exc:
+        return jsonify({"ok": False, "error": str(exc)}), 400
+    previous = dict(ROOM_MAP)
+    ROOM_MAP.clear()
+    ROOM_MAP.update(reordered)
+    try:
+        _persist_room_map()
+    except OSError:
+        ROOM_MAP.clear()
+        ROOM_MAP.update(previous)
+        return jsonify({"ok": False, "error": "cannot persist rooms"}), 500
+    return jsonify({"ok": True, "rooms": ROOM_MAP})
 
 
 @app.route("/rooms/<room_id>", methods=["PUT", "PATCH", "DELETE"])
@@ -500,6 +522,7 @@ app.add_url_rule(
 )
 app.add_url_rule(f"{_HA_PREFIX}/devices", "ha_devices", devices_list)
 app.add_url_rule(f"{_HA_PREFIX}/rooms", "ha_rooms", rooms)
+app.add_url_rule(f"{_HA_PREFIX}/rooms/order", "ha_rooms_order", rooms_order, methods=["PUT"])
 app.add_url_rule(
     f"{_HA_PREFIX}/rooms/<room_id>",
     "ha_rooms_item",

--- a/src/intercom_server.py
+++ b/src/intercom_server.py
@@ -15,10 +15,12 @@ from const import (
 from firmware import (
     FirmwareError,
     ensure_latest_firmware,
+    firmware_cache_status,
     firmware_checksum_headers,
     load_cached_firmware,
     schedule_firmware_refresh,
     start_firmware_poller,
+    sync_firmware_cache,
 )
 from flask import Flask, jsonify, request, send_from_directory
 from rooms import (
@@ -480,6 +482,23 @@ def devices_hello():
     return jsonify(device_hello_payload(device, valid_rooms=set(ROOM_MAP)))
 
 
+@app.route("/firmware/status")
+def firmware_status():
+    """Cached GitHub firmware version for the PWA settings panel."""
+    return jsonify(firmware_cache_status(FIRMWARE_DIR))
+
+
+@app.route("/firmware/sync", methods=["POST"])
+def firmware_sync():
+    """Fetch the latest GitHub release into the cache. LAN trust, same as /chime POST."""
+    try:
+        cached, updated = sync_firmware_cache(FIRMWARE_DIR)
+    except FirmwareError as exc:
+        app.logger.warning("[intercom] firmware sync failed: %s", exc)
+        return jsonify({"ok": False, "error": "firmware unavailable"}), 502
+    return jsonify({"ok": True, "version": cached.version, "updated": updated})
+
+
 @app.route("/api/home_intercom/firmware")
 def firmware_bin():
     """Cached GitHub .bin for ESP32 OTA (LAN HTTP)."""
@@ -538,6 +557,8 @@ app.add_url_rule(f"{_HA_PREFIX}/record", "ha_record", record, methods=["POST"])
 app.add_url_rule("/device/record", "device_record", record, methods=["POST"])
 app.add_url_rule(f"{_HA_PREFIX}/device/record", "ha_device_record", record, methods=["POST"])
 app.add_url_rule(f"{_HA_PREFIX}/chime", "ha_chime", chime, methods=["GET", "POST", "DELETE"])
+app.add_url_rule(f"{_HA_PREFIX}/firmware/status", "ha_firmware_status", firmware_status)
+app.add_url_rule(f"{_HA_PREFIX}/firmware/sync", "ha_firmware_sync", firmware_sync, methods=["POST"])
 app.add_url_rule(f"{_HA_PREFIX}/audio/<path:filename>", "ha_audio", serve_audio)
 app.add_url_rule(f"{_HA_PREFIX}/static/<path:filename>", "ha_static", static_files)
 

--- a/tests/docker-smoke/run.sh
+++ b/tests/docker-smoke/run.sh
@@ -174,6 +174,15 @@ print(f'ok: version={d[\"version\"]}')
 # 1c. GET /api/home_intercom/firmware — empty cache is 404
 assert_http "GET /api/home_intercom/firmware — empty cache → 404" \
     "$(fetch_code "${URL}/api/home_intercom/firmware")" "404"
+FW_STATUS=$(fetch "${URL}/firmware/status" || echo "")
+assert_json "GET /firmware/status — empty cache" "${FW_STATUS}" "
+import sys, json
+d = json.load(sys.stdin)
+assert d.get('version') == '', f'expected empty version, got: {d}'
+print('ok: no cached firmware')
+"
+assert_ha_alias "GET /api/home_intercom/firmware/status — matches /firmware/status" \
+    "${FW_STATUS}" "/api/home_intercom/firmware/status"
 
 # 1b. /config — global audio settings (issue #39)
 CFG=$(fetch "${URL}/config" || echo "")

--- a/tests/docker-smoke/run.sh
+++ b/tests/docker-smoke/run.sh
@@ -238,6 +238,18 @@ print('ok: renamed')
 "
 assert_ha_alias "PUT /api/home_intercom/rooms/office — matches /rooms after write" \
     "$(fetch "${URL}/rooms" || echo "")" "/api/home_intercom/rooms"
+ORDER=$(fetch -X PUT -H "Content-Type: application/json" \
+    -d '{"order":["office","test"]}' "${URL}/rooms/order" || echo "")
+assert_json "PUT /rooms/order" "${ORDER}" "
+import sys, json
+d = json.load(sys.stdin)
+assert d.get('ok') is True, f'not ok: {d}'
+assert list(d['rooms']) == ['office', 'test'], d
+print('ok: reordered')
+"
+assert_eq "GET /rooms key order" \
+    "$(fetch "${URL}/rooms" | python3 -c 'import sys,json; print(list(json.load(sys.stdin)))')" \
+    "['office', 'test']"
 DEL=$(fetch -X DELETE "${URL}/rooms/office" || echo "")
 assert_json "DELETE /rooms/office" "${DEL}" "
 import sys, json

--- a/tests/docker-smoke/run.sh
+++ b/tests/docker-smoke/run.sh
@@ -219,13 +219,14 @@ print('ok: test room created')
 
 # 2b. PUT/PATCH/DELETE /rooms/<id> — writable catalog (issue #72)
 PUT=$(fetch -X PUT -H "Content-Type: application/json" \
-    -d '{"name":"Office","entity":"media_player.office","announce_volume":40}' \
+    -d '{"name":"Office","entity":"media_player.office","announce_volume":40,"icon":"📺"}' \
     "${URL}/rooms/office" || echo "")
 assert_json "PUT /rooms/office" "${PUT}" "
 import sys, json
 d = json.load(sys.stdin)
 assert d.get('ok') is True, f'not ok: {d}'
 assert d['rooms']['office']['entity'] == 'media_player.office'
+assert d['rooms']['office']['icon'] == '📺', d
 print('ok: office created')
 "
 PATCH=$(fetch -X PATCH -H "Content-Type: application/json" \

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -709,6 +709,7 @@ class TestRegisterApiViews:
             PanelView,
             RecordView,
             RoomsItemView,
+            RoomsOrderView,
             StaticAliasView,
             StaticView,
             register_api_views,
@@ -721,6 +722,7 @@ class TestRegisterApiViews:
         assert RecordView in calls
         assert MediaPlayersView in calls
         assert RoomsItemView in calls
+        assert RoomsOrderView in calls
         assert ChimeView in calls
         assert DeviceRecordView in calls
         assert DevicesApproveView in calls
@@ -996,6 +998,38 @@ class TestRoomsItemView:
         resp = await RoomsItemView().delete(req, "study")
         assert resp.status == 404
         assert json.loads(resp.text)["error"] == "unknown room"
+
+
+class TestRoomsOrderView:
+    """PUT /api/home_intercom/rooms/order (issue #76)."""
+
+    def _req(self, token: str, body: dict, *, hass: MagicMock | None = None) -> MagicMock:
+        req = _make_request()
+        req.app = {"hass": hass or _make_hass()}
+        req.headers = {"X-PWA-Token": token}
+        req.json = AsyncMock(return_value=body)
+        return req
+
+    @pytest.mark.asyncio
+    async def test_put_reorders_keys(self):
+        from custom_components.home_intercom.api import RoomsOrderView
+
+        hass = _make_hass()
+        req = self._req(PWA_TOKEN, {"order": ["bedroom", "living_room"]}, hass=hass)
+        resp = await RoomsOrderView().put(req)
+        assert resp.status == 200
+        rooms = json.loads(resp.text)["rooms"]
+        assert list(rooms) == ["bedroom", "living_room"]
+
+    @pytest.mark.asyncio
+    async def test_put_rejects_partial_list(self):
+        from custom_components.home_intercom.api import RoomsOrderView
+
+        hass = _make_hass()
+        req = self._req(PWA_TOKEN, {"order": ["bedroom"]}, hass=hass)
+        resp = await RoomsOrderView().put(req)
+        assert resp.status == 400
+        assert json.loads(resp.text)["error"] == "invalid order"
 
 
 # ——— ChimeView tests (issue #66) ———

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -703,6 +703,8 @@ class TestRegisterApiViews:
             DevicesApproveView,
             DevicesManageView,
             FirmwareSigView,
+            FirmwareStatusView,
+            FirmwareSyncView,
             FirmwareView,
             MediaPlayersView,
             PanelAliasView,
@@ -728,6 +730,8 @@ class TestRegisterApiViews:
         assert DevicesApproveView in calls
         assert DevicesManageView in calls
         assert FirmwareView in calls
+        assert FirmwareStatusView in calls
+        assert FirmwareSyncView in calls
         assert FirmwareSigView in calls
         assert PanelView in calls
         assert PanelAliasView in calls
@@ -1154,3 +1158,71 @@ class TestFirmwareView:
         resp = await FirmwareSigView().get(req)
         assert resp.status == 200
         assert resp.body == sig
+
+
+class TestFirmwareCacheViews:
+    @pytest.mark.asyncio
+    async def test_status_empty(self):
+        from custom_components.home_intercom.api import FirmwareStatusView
+
+        req = _make_request()
+        req.app = {"hass": _make_hass()}
+        resp = await FirmwareStatusView().get(req)
+        assert resp.status == 200
+        assert json.loads(resp.text) == {"version": ""}
+
+    @pytest.mark.asyncio
+    async def test_status_cached(self):
+        from custom_components.home_intercom.api import FirmwareStatusView
+
+        hass = _make_hass()
+        _seed_firmware_cache(Path(hass.data["home_intercom"]["audio_dir"]) / "firmware", b"bin")
+        req = _make_request()
+        req.app = {"hass": hass}
+        resp = await FirmwareStatusView().get(req)
+        assert json.loads(resp.text) == {"version": "0.2.0"}
+
+    @pytest.mark.asyncio
+    async def test_sync_ok(self):
+        from custom_components.home_intercom.api import FirmwareSyncView
+        from custom_components.home_intercom.firmware import CachedFirmware
+
+        hass = _make_hass()
+        req = _make_request()
+        req.headers = {"X-PWA-Token": PWA_TOKEN}
+        req.app = {"hass": hass}
+        cached = CachedFirmware(version="0.2.1", sha256="ab", bin_path="x")
+        with patch(
+            "custom_components.home_intercom.api.sync_firmware_cache",
+            return_value=(cached, True),
+        ):
+            resp = await FirmwareSyncView().post(req)
+        assert resp.status == 200
+        assert json.loads(resp.text) == {"ok": True, "version": "0.2.1", "updated": True}
+
+    @pytest.mark.asyncio
+    async def test_sync_unauthorized(self):
+        from custom_components.home_intercom.api import FirmwareSyncView
+
+        req = _make_request()
+        req.headers = {}
+        req.app = {"hass": _make_hass()}
+        resp = await FirmwareSyncView().post(req)
+        assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_sync_unavailable(self):
+        from custom_components.home_intercom.api import FirmwareSyncView
+        from custom_components.home_intercom.firmware import FirmwareError
+
+        hass = _make_hass()
+        req = _make_request()
+        req.headers = {"X-PWA-Token": PWA_TOKEN}
+        req.app = {"hass": hass}
+        with patch(
+            "custom_components.home_intercom.api.sync_firmware_cache",
+            side_effect=FirmwareError("github down"),
+        ):
+            resp = await FirmwareSyncView().post(req)
+        assert resp.status == 502
+        assert json.loads(resp.text)["error"] == "firmware unavailable"

--- a/tests/test_firmware.py
+++ b/tests/test_firmware.py
@@ -14,9 +14,11 @@ from firmware import (
     CachedFirmware,
     FirmwareError,
     ensure_latest_firmware,
+    firmware_cache_status,
     load_cached_firmware,
     refresh_cached_firmware,
     start_firmware_poller,
+    sync_firmware_cache,
 )
 from shared import devices_payload, firmware_update_available, normalize_firmware_version
 
@@ -116,6 +118,44 @@ def test_devices_payload_marks_outdated_and_current():
 def test_load_cached_firmware_empty(tmp_path):
     assert load_cached_firmware(str(tmp_path)) is None
     assert load_cached_firmware("") is None
+
+
+def test_firmware_cache_status_empty_and_cached(tmp_path):
+    cache = tmp_path / "firmware"
+    assert firmware_cache_status(str(cache)) == {"version": ""}
+    mapping = {API_URL: _latest_json(), BIN_URL: BLOB}
+    with patch("firmware.urllib.request.urlopen", side_effect=_urlopen_map(mapping)):
+        ensure_latest_firmware(str(cache))
+    assert firmware_cache_status(str(cache)) == {"version": "0.2.0"}
+
+
+def test_sync_firmware_cache_updated_then_fresh(tmp_path):
+    cache = tmp_path / "firmware"
+    mapping = {API_URL: _latest_json(), BIN_URL: BLOB}
+    with patch("firmware.urllib.request.urlopen", side_effect=_urlopen_map(mapping)):
+        cached, updated = sync_firmware_cache(str(cache))
+    assert updated is True
+    assert cached.version == "0.2.0"
+    with patch("firmware.urllib.request.urlopen", side_effect=_urlopen_map(mapping)):
+        _, again = sync_firmware_cache(str(cache))
+    assert again is False
+
+
+def test_sync_firmware_cache_raises_without_stale_fallback(tmp_path):
+    cache = tmp_path / "firmware"
+    mapping = {API_URL: _latest_json(), BIN_URL: BLOB}
+    with patch("firmware.urllib.request.urlopen", side_effect=_urlopen_map(mapping)):
+        sync_firmware_cache(str(cache))
+
+    def _fail(req, timeout=None):
+        raise urllib.error.URLError("github down")
+
+    with (
+        patch("firmware.urllib.request.urlopen", side_effect=_fail),
+        pytest.raises(FirmwareError),
+    ):
+        sync_firmware_cache(str(cache))
+    assert load_cached_firmware(str(cache)).version == "0.2.0"
 
 
 def test_ensure_latest_downloads_and_caches(tmp_path):

--- a/tests/test_html_quality.py
+++ b/tests/test_html_quality.py
@@ -90,6 +90,15 @@ I18N_REQUIRED_KEYS = [
     "roomsErrorNoEntry",
     "roomsErrorUnknown",
     "roomsDrag",
+    "firmwareTitle",
+    "firmwareDesc",
+    "firmwareSync",
+    "firmwareNone",
+    "firmwareCached",
+    "firmwareUpdated",
+    "firmwareLatest",
+    "firmwareSyncFail",
+    "firmwareSyncing",
 ]
 
 CHINESE_STATUS_STRINGS = [
@@ -306,6 +315,11 @@ class TestHtmlStructure:
         assert ".rooms-icon-picker" in css
         assert ".rooms-icon-opt.selected" in css
         assert ".room-card.dragging" not in css
+        assert 'id="firmware-sync"' in html_content
+        assert "/firmware/sync" in html_content
+        assert "/firmware/status" in html_content
+        assert "syncFirmwareCache" in js
+        assert ".firmware-section" in css
 
 
 class TestJsSyntax:

--- a/tests/test_html_quality.py
+++ b/tests/test_html_quality.py
@@ -88,6 +88,7 @@ I18N_REQUIRED_KEYS = [
     "roomsPlayerRemoved",
     "roomsErrorNoEntry",
     "roomsErrorUnknown",
+    "roomsDrag",
 ]
 
 CHINESE_STATUS_STRINGS = [
@@ -274,6 +275,13 @@ class TestHtmlStructure:
         assert "method: editId ? 'PATCH' : 'PUT'" in js
         assert "method: 'DELETE'" in js
         assert "renderRoomsSettings" in js
+        assert "draggable = true" in js
+        assert "function dragStart" in js
+        assert "function dragOver" in js
+        assert "function isBefore" in js
+        assert "persistRoomOrder" in js
+        assert "/rooms/order" in js
+        assert "dataset.roomId" in js
         css_path = os.path.join(
             os.path.dirname(__file__),
             "..",
@@ -289,6 +297,8 @@ class TestHtmlStructure:
         assert "overflow: hidden auto" in css
         assert ".rooms-player-missing" in css
         assert ".rooms-row-entity-missing" in css
+        assert ".rooms-row.dragging" in css
+        assert ".room-card.dragging" not in css
 
 
 class TestJsSyntax:

--- a/tests/test_html_quality.py
+++ b/tests/test_html_quality.py
@@ -71,6 +71,7 @@ I18N_REQUIRED_KEYS = [
     "roomsEmpty",
     "roomsAdd",
     "roomsName",
+    "roomsIcon",
     "roomsPlayer",
     "roomsVolume",
     "roomsPause",
@@ -265,6 +266,10 @@ class TestHtmlStructure:
         assert 'id="room-name"' in html_content
         assert 'id="room-volume"' in html_content
         assert 'id="room-pause"' in html_content
+        assert 'id="room-icon-picker"' in html_content
+        assert 'id="room-icon"' in html_content
+        assert "fillIconPicker" in js
+        assert "ROOM_ICON_PRESETS" in js
         assert "/media_players" in html_content
         assert "GRID.innerHTML = ''" in js or 'GRID.innerHTML = ""' in js
         assert "rebuildRoomGrid" in js
@@ -298,6 +303,8 @@ class TestHtmlStructure:
         assert ".rooms-player-missing" in css
         assert ".rooms-row-entity-missing" in css
         assert ".rooms-row.dragging" in css
+        assert ".rooms-icon-picker" in css
+        assert ".rooms-icon-opt.selected" in css
         assert ".room-card.dragging" not in css
 
 

--- a/tests/test_html_quality.py
+++ b/tests/test_html_quality.py
@@ -289,10 +289,9 @@ class TestHtmlStructure:
         assert "method: editId ? 'PATCH' : 'PUT'" in js
         assert "method: 'DELETE'" in js
         assert "renderRoomsSettings" in js
-        assert "draggable = true" in js
-        assert "function dragStart" in js
-        assert "function dragOver" in js
-        assert "function isBefore" in js
+        assert "rooms-row-sortable" in js
+        assert "function onReorderPointerDown" in js
+        assert "function beginReorder" in js
         assert "persistRoomOrder" in js
         assert "/rooms/order" in js
         assert "dataset.roomId" in js
@@ -312,6 +311,7 @@ class TestHtmlStructure:
         assert ".rooms-player-missing" in css
         assert ".rooms-row-entity-missing" in css
         assert ".rooms-row.dragging" in css
+        assert ".rooms-row-sortable" in css
         assert ".rooms-icon-picker" in css
         assert ".rooms-icon-opt.selected" in css
         assert ".room-card.dragging" not in css

--- a/tests/test_intercom_server.py
+++ b/tests/test_intercom_server.py
@@ -578,6 +578,71 @@ class TestFirmwareRoute:
         assert resp.data == sig
 
 
+class TestFirmwareCacheRoutes:
+    def test_status_empty(self, client, monkeypatch, tmp_path):
+        import intercom_server
+
+        monkeypatch.setattr(intercom_server, "FIRMWARE_DIR", str(tmp_path / "firmware"))
+        resp = client.get("/firmware/status")
+        assert resp.status_code == 200
+        assert resp.json == {"version": ""}
+        alias = client.get("/api/home_intercom/firmware/status")
+        assert alias.status_code == 200
+        assert alias.json == {"version": ""}
+
+    def test_status_cached(self, client, monkeypatch, tmp_path):
+        import hashlib
+        import json
+
+        import intercom_server
+
+        cache = tmp_path / "firmware"
+        cache.mkdir()
+        blob = b"esp32-bin"
+        sha = hashlib.sha256(blob).hexdigest()
+        (cache / "firmware.bin").write_bytes(blob)
+        (cache / "firmware.json").write_text(json.dumps({"version": "0.2.0", "sha256": sha}))
+        monkeypatch.setattr(intercom_server, "FIRMWARE_DIR", str(cache))
+        resp = client.get("/firmware/status")
+        assert resp.json == {"version": "0.2.0"}
+
+    def test_sync_ok(self, client, monkeypatch, tmp_path):
+        from firmware import CachedFirmware
+
+        import intercom_server
+
+        monkeypatch.setattr(intercom_server, "FIRMWARE_DIR", str(tmp_path / "firmware"))
+        monkeypatch.setattr(
+            intercom_server,
+            "sync_firmware_cache",
+            lambda _dir: (
+                CachedFirmware(version="0.2.1", sha256="ab", bin_path="x"),
+                True,
+            ),
+        )
+        resp = client.post("/firmware/sync")
+        assert resp.status_code == 200
+        assert resp.json == {"ok": True, "version": "0.2.1", "updated": True}
+        alias = client.post("/api/home_intercom/firmware/sync")
+        assert alias.status_code == 200
+        assert alias.json["updated"] is True
+
+    def test_sync_unavailable(self, client, monkeypatch, tmp_path):
+        from firmware import FirmwareError
+
+        import intercom_server
+
+        monkeypatch.setattr(intercom_server, "FIRMWARE_DIR", str(tmp_path / "firmware"))
+
+        def _fail(_dir):
+            raise FirmwareError("github down")
+
+        monkeypatch.setattr(intercom_server, "sync_firmware_cache", _fail)
+        resp = client.post("/firmware/sync")
+        assert resp.status_code == 502
+        assert resp.json["error"] == "firmware unavailable"
+
+
 class TestVersionRoute:
     def test_returns_version_json(self, client):
         resp = client.get("/version")

--- a/tests/test_intercom_server.py
+++ b/tests/test_intercom_server.py
@@ -102,6 +102,20 @@ class TestRoomsWrite:
         got = rooms_client.get("/rooms").json
         assert got["office"]["name"] == "Office"
 
+    def test_put_stores_icon(self, rooms_client):
+        resp = rooms_client.put(
+            "/rooms/office",
+            json={"name": "Office", "entity": "media_player.office", "icon": "💻"},
+        )
+        assert resp.status_code == 200
+        assert resp.json["rooms"]["office"]["icon"] == "💻"
+        assert rooms_client.get("/rooms").json["office"]["icon"] == "💻"
+        bad = rooms_client.put(
+            "/rooms/office",
+            json={"name": "Office", "entity": "media_player.office", "icon": "🚀"},
+        )
+        assert bad.status_code == 400
+
     def test_put_ha_alias(self, rooms_client):
         resp = rooms_client.put(
             "/api/home_intercom/rooms/office",

--- a/tests/test_intercom_server.py
+++ b/tests/test_intercom_server.py
@@ -154,6 +154,27 @@ class TestRoomsWrite:
         assert resp.status_code == 500
         assert resp.json["error"] == "cannot persist rooms"
 
+    def test_put_order(self, rooms_client, monkeypatch):
+        import intercom_server
+
+        monkeypatch.setattr(intercom_server, "ROOM_MAP", {})
+        rooms_client.put("/rooms/office", json={"name": "Office", "entity": "media_player.office"})
+        rooms_client.put("/rooms/den", json={"name": "Den", "entity": "media_player.den"})
+        resp = rooms_client.put("/rooms/order", json={"order": ["den", "office"]})
+        assert resp.status_code == 200
+        assert list(resp.json["rooms"]) == ["den", "office"]
+        assert list(rooms_client.get("/rooms").json) == ["den", "office"]
+        alias = rooms_client.put(
+            "/api/home_intercom/rooms/order",
+            json={"order": ["office", "den"]},
+        )
+        assert alias.status_code == 200
+        assert list(alias.json["rooms"]) == ["office", "den"]
+
+    def test_put_order_rejects_unknown(self, rooms_client):
+        resp = rooms_client.put("/rooms/order", json={"order": ["mars"]})
+        assert resp.status_code == 400
+
 
 class TestDevicesRoute:
     """GET /devices + HA alias — read-only registry listing (issue #52)."""

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -10,9 +10,11 @@ from rooms import (
     PLAY_MEDIA,
     RoomValidationError,
     catalog_from_ha_states,
+    combined_entry_rooms,
     load_rooms,
     patch_room,
     put_room,
+    reorder_rooms,
     room_entity,
     save_rooms,
     sort_media_player_catalog,
@@ -29,6 +31,8 @@ class TestValidateRoomKey:
             validate_room_key("all")
         with pytest.raises(RoomValidationError, match="invalid room id"):
             validate_room_key("status")
+        with pytest.raises(RoomValidationError, match="invalid room id"):
+            validate_room_key("order")
 
     def test_rejects_empty(self) -> None:
         with pytest.raises(RoomValidationError, match="invalid room id"):
@@ -88,6 +92,28 @@ class TestPutPatch:
     def test_room_entity_reads_both_keys(self) -> None:
         assert room_entity({"entity": "media_player.a"}) == "media_player.a"
         assert room_entity({"entity_id": "media_player.b"}) == "media_player.b"
+
+
+class TestReorder:
+    def test_permutes_keys(self) -> None:
+        rooms = {"a": {"name": "A"}, "b": {"name": "B"}}
+        assert list(reorder_rooms(rooms, ["b", "a"])) == ["b", "a"]
+
+    def test_rejects_bad_order(self) -> None:
+        rooms = {"a": {"name": "A"}}
+        with pytest.raises(RoomValidationError, match="unknown room"):
+            reorder_rooms(rooms, ["mars"])
+        with pytest.raises(RoomValidationError, match="invalid order"):
+            reorder_rooms(rooms, [])
+        with pytest.raises(RoomValidationError, match="invalid order"):
+            reorder_rooms(rooms, ["a", "a"])
+
+    def test_combined_entry_options_key_order_wins(self) -> None:
+        class Entry:
+            data = {"rooms": {"a": {"name": "A"}, "b": {"name": "B"}}}
+            options = {"rooms": {"b": {"name": "B"}, "a": {"name": "A"}}}
+
+        assert list(combined_entry_rooms(Entry())) == ["b", "a"]
 
 
 class TestLoadSave:

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -89,6 +89,37 @@ class TestPutPatch:
         with pytest.raises(RoomValidationError, match="empty patch"):
             patch_room({"name": "A", "entity": "media_player.a"}, {}, entity_key="entity")
 
+    def test_put_stores_icon(self) -> None:
+        room = put_room(
+            {"name": "Study", "entity": "media_player.study", "icon": "📚"},
+            entity_key="entity",
+        )
+        assert room["icon"] == "📚"
+
+    def test_put_rejects_unknown_icon(self) -> None:
+        with pytest.raises(RoomValidationError, match="invalid icon"):
+            put_room(
+                {"name": "Study", "entity": "media_player.study", "icon": "🚀"},
+                entity_key="entity",
+            )
+
+    def test_put_empty_icon_omits_field(self) -> None:
+        room = put_room(
+            {"name": "Study", "entity": "media_player.study", "icon": ""},
+            entity_key="entity",
+        )
+        assert "icon" not in room
+
+    def test_patch_clears_icon(self) -> None:
+        existing = {
+            "name": "Study",
+            "entity": "media_player.study",
+            "icon": "📚",
+        }
+        room = patch_room(existing, {"icon": None}, entity_key="entity")
+        assert "icon" not in room
+        assert room["name"] == "Study"
+
     def test_room_entity_reads_both_keys(self) -> None:
         assert room_entity({"entity": "media_player.a"}) == "media_player.a"
         assert room_entity({"entity_id": "media_player.b"}) == "media_player.b"


### PR DESCRIPTION
## Summary
- Drag rooms in Settings to persist catalog order (`PUT /rooms/order`); the grid comes back the same after refresh. **All** stays first and is not in the list (#76).
- Add/edit room includes an allowlisted emoji picker; `icon` is stored on the room and used on the grid and settings list. Missing/invalid falls back to the old key map or 🔊. **All** stays 📢 (#85).
- Settings has Sync for the GitHub `intercom-button` firmware cache so a new release is available for OTA without waiting for the hourly poll.

## Test plan
- [x] Settings → Rooms: drag two rooms, refresh; grid and list keep the new order (HA and Docker).
- [x] Add and edit a room, pick an icon other than 🔊, save; grid card and settings row match. Refresh still shows it.
- [x] **All** stays 📢 and is not in the settings list / catalog.
- [x] Settings → Button firmware: Sync reports cached vs already-latest; device Update badges refresh when the cache is newer than a button.
- [x] Switch zh-CN / en on the new strings (rooms icon, drag label, firmware section).

Closes #76
Closes #85

Made with [Cursor](https://cursor.com)